### PR TITLE
Aggregation - comments requested

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -251,8 +251,8 @@ class ConfigurationManager(object):
             sys.exit()
 
         self.config = self.get_config()
-        changes = self.do_aggregations()
-        if changes:
+        config_invalidated = self.do_aggregations()
+        if config_invalidated:  # must regenerate config
             self.config = self.get_config()
 
     #--------------------------------------------------------------------------
@@ -389,7 +389,6 @@ class ConfigurationManager(object):
             source = self.option_definitions
             local_namespace = self.config
         changes_made = False
-        val_dict = dict()
         for key, val in source.items():
             if isinstance(val, Namespace):
                 changes_made = changes_made or \

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -233,6 +233,8 @@ class ConfigurationManager(object):
         # third pass to get values - complain about bad options
         self.overlay_settings(ignore_mismatches=False)
 
+        self.fill_in_templates()
+
         if use_auto_help and self.get_option_by_name('help').value:
             self.output_summary()
             admin_tasks_done = True
@@ -377,6 +379,17 @@ class ConfigurationManager(object):
             elif value_type == Namespace:
                 destination[key] = d = DotDict()
                 self.walk_config_copy_values(val, d)
+
+    #--------------------------------------------------------------------------
+    def fill_in_template(self, source=None):
+        if source is None:
+            source = self.option_definitions
+        val_dict = dict(k, v.value in source.items())
+        for key, val in source.items():
+            if isinstance(val, Namespace):
+                self.fill_in_template(val)
+            else val.is_template:
+                val.set_value(val.value % val_dict)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -159,8 +159,6 @@ class ConfigurationManager(object):
                         # will be stored here.
 
         self._config = None  # eventual container for DOM-like config object
-        self._config_dirty = True  # flag to indicate that the _config needs
-                                   # regeneration
 
         self.argv_source = argv_source
         self.option_definitions = Namespace()
@@ -259,9 +257,8 @@ class ConfigurationManager(object):
     #--------------------------------------------------------------------------
     @property
     def config(self):
-        if self._config is None or self._config_dirty:
+        if self._config is None:
             self._config = self.generate_config()
-            self._config_dirty = False
         return self._config
 
     #--------------------------------------------------------------------------
@@ -409,7 +406,7 @@ class ConfigurationManager(object):
                 self.aggregate(val, local_namespace[key])
             elif isinstance(val, Aggregation):
                 val.aggregate(self.config, local_namespace, self.args)
-                self._config_dirty = True
+                self._config = None
             # skip Options, we're only dealing with Aggregations
 
     #--------------------------------------------------------------------------

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -255,7 +255,6 @@ class ConfigurationManager(object):
         if changes:
             self.config = self.get_config()
 
-
     #--------------------------------------------------------------------------
     def walk_expanding_class_options(self, source_namespace=None,
                                      parent_namespace=None):

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -381,15 +381,19 @@ class ConfigurationManager(object):
                 self.walk_config_copy_values(val, d)
 
     #--------------------------------------------------------------------------
-    def fill_in_template(self, source=None):
+    def fill_in_templates(self, source=None):
         if source is None:
             source = self.option_definitions
-        val_dict = dict(k, v.value in source.items())
+        val_dict = dict()
+        for k, v in source.iteritems():
+            if isinstance(v, Namespace):
+                continue
+            val_dict[k] = v.value
         for key, val in source.items():
             if isinstance(val, Namespace):
-                self.fill_in_template(val)
-            else val.is_template:
-                val.set_value(val.value % val_dict)
+                self.fill_in_templates(val)
+            elif val.is_template:
+                val.do_set_value(val.value % val_dict)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/configman/def_sources/for_mappings.py
+++ b/configman/def_sources/for_mappings.py
@@ -47,17 +47,21 @@ def setup_definitions(source, destination):
     for key, val in source.items():
         if key.startswith('__'):
             continue  # ignore these
-        val_type = type(val)
-        if val_type == option.Option:
+        if isinstance(val, option.Option):
             destination[key] = val
             if not val.name:
                 val.name = key
             val.set_value(val.default)
+        elif isinstance(val, option.Aggregation):
+            destination[key] = val
         elif isinstance(val, collections.Mapping):
             if 'name' in val and 'default' in val:
                 # this is an Option in the form of a dict, not a Namespace
                 params = converters.str_dict_keys(val)
                 destination[key] = option.Option(**params)
+            elif 'aggregate_fn' in val:  # this is an Aggregation
+                params = converters.str_dict_keys(val)
+                destination[key] = option.Aggregation(**params)
             else:
                 # this is a Namespace
                 if key not in destination:
@@ -67,7 +71,7 @@ def setup_definitions(source, destination):
                         destination[key] = namespace.Namespace()
                 # recurse!
                 setup_definitions(val, destination[key])
-        elif val_type in [int, float, str, unicode]:
+        elif type(val) in [int, float, str, unicode]:
             destination[key] = option.Option(name=key,
                                       doc=key,
                                       default=val)

--- a/configman/def_sources/for_mappings.py
+++ b/configman/def_sources/for_mappings.py
@@ -42,6 +42,7 @@ from .. import converters
 from .. import namespace
 from .. import option
 
+
 #------------------------------------------------------------------------------
 def setup_definitions(source, destination):
     for key, val in source.items():

--- a/configman/def_sources/for_mappings.py
+++ b/configman/def_sources/for_mappings.py
@@ -59,7 +59,7 @@ def setup_definitions(source, destination):
                 # this is an Option in the form of a dict, not a Namespace
                 params = converters.str_dict_keys(val)
                 destination[key] = option.Option(**params)
-            elif 'aggregate_fn' in val:  # this is an Aggregation
+            elif 'aggregation_fn' in val:  # this is an Aggregation
                 params = converters.str_dict_keys(val)
                 destination[key] = option.Aggregation(**params)
             else:

--- a/configman/def_sources/for_mappings.py
+++ b/configman/def_sources/for_mappings.py
@@ -60,7 +60,7 @@ def setup_definitions(source, destination):
                 # this is an Option in the form of a dict, not a Namespace
                 params = converters.str_dict_keys(val)
                 destination[key] = option.Option(**params)
-            elif 'aggregation_fn' in val:  # this is an Aggregation
+            elif 'function' in val:  # this is an Aggregation
                 params = converters.str_dict_keys(val)
                 destination[key] = option.Aggregation(**params)
             else:
@@ -72,7 +72,7 @@ def setup_definitions(source, destination):
                         destination[key] = namespace.Namespace()
                 # recurse!
                 setup_definitions(val, destination[key])
-        elif type(val) in [int, float, str, unicode]:
+        elif isinstance(val, (int, long, float, str, unicode)):
             destination[key] = option.Option(name=key,
                                       doc=key,
                                       default=val)

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -60,12 +60,14 @@ class Namespace(dotdict.DotDict):
                    default=None,
                    doc=None,
                    from_string_converter=None,
-                   short_form=None):
+                   short_form=None,
+                   is_template=False):
         an_option = Option(name,
                            doc=doc,
                            default=default,
                            from_string_converter=from_string_converter,
-                           short_form=short_form)
+                           short_form=short_form,
+                           is_template=is_template)
         self[name] = an_option
 
     #--------------------------------------------------------------------------

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -69,8 +69,8 @@ class Namespace(dotdict.DotDict):
         self[name] = an_option
 
     #--------------------------------------------------------------------------
-    def add_aggregation(self, name, aggregation_fn):
-        an_aggregation = Aggregation(name, aggregation_fn)
+    def add_aggregation(self, name, function):
+        an_aggregation = Aggregation(name, function)
         self[name] = an_aggregation
 
     #--------------------------------------------------------------------------

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -37,7 +37,7 @@
 # ***** END LICENSE BLOCK *****
 
 import dotdict
-from option import Option
+from option import Option, Aggregation
 
 
 class Namespace(dotdict.DotDict):
@@ -60,15 +60,18 @@ class Namespace(dotdict.DotDict):
                    default=None,
                    doc=None,
                    from_string_converter=None,
-                   short_form=None,
-                   is_template=False):
+                   short_form=None):
         an_option = Option(name,
                            doc=doc,
                            default=default,
                            from_string_converter=from_string_converter,
-                           short_form=short_form,
-                           is_template=is_template)
+                           short_form=short_form)
         self[name] = an_option
+
+    #--------------------------------------------------------------------------
+    def add_aggregation(self, name, aggregation_fn):
+        an_aggregation = Aggregation(name, aggregation_fn)
+        self[name] = an_aggregation
 
     #--------------------------------------------------------------------------
     def namespace(self, name, doc=''):

--- a/configman/option.py
+++ b/configman/option.py
@@ -51,7 +51,6 @@ class Option(object):
                  from_string_converter=None,
                  value=None,
                  short_form=None,
-                 is_template=False,
                  *args,
                  **kwargs):
         self.name = name
@@ -67,8 +66,6 @@ class Option(object):
         self.from_string_converter = from_string_converter
         if value is None:
             value = default
-        self.initialize_value(value)
-
         self.set_value(value)
         if (type(self.value) != type(self.default)
             and self.from_string_converter):
@@ -121,7 +118,10 @@ class Aggregation(object):
     def __init__(self,
                  name,
                  aggregation_fn):
-
+        self.name = name
+        self.aggregation_fn = aggregation_fn
+        self.value = None
 
     #--------------------------------------------------------------------------
-    def set_value(self, val):
+    def aggregate(self, all_options, local_namespace, args):
+        self.value = self.aggregation_fn(all_options, local_namespace, args)

--- a/configman/option.py
+++ b/configman/option.py
@@ -41,11 +41,11 @@ import collections
 import converters as conv
 from config_exceptions import CannotConvertError
 
-
+#==============================================================================
 class Option(object):
-
     #--------------------------------------------------------------------------
-    def __init__(self, name,
+    def __init__(self,
+                 name,
                  default=None,
                  doc=None,
                  from_string_converter=None,
@@ -58,7 +58,6 @@ class Option(object):
         self.short_form = short_form
         self.default = default
         self.doc = doc
-        self.is_template = is_template
         if from_string_converter is None:
             if default is not None:
                 # take a qualified guess from the default value
@@ -66,13 +65,10 @@ class Option(object):
         if isinstance(from_string_converter, basestring):
             from_string_converter = conv.class_converter(from_string_converter)
         self.from_string_converter = from_string_converter
-
         if value is None:
             value = default
-        if is_template:
-            self.value = default
-            return # we want to avoid calling the coverter on template
-                   # options until the very end
+        self.initialize_value(value)
+
         self.set_value(value)
         if (type(self.value) != type(self.default)
             and self.from_string_converter):
@@ -105,12 +101,6 @@ class Option(object):
 
     #--------------------------------------------------------------------------
     def set_value(self, val):
-        if self.is_template:
-            return
-        self.do_set_value(val)
-
-    #--------------------------------------------------------------------------
-    def do_set_value(self, val):
         if isinstance(val, basestring):
             try:
                 self.value = self.from_string_converter(val)
@@ -124,3 +114,14 @@ class Option(object):
             self.set_value(val["default"])
         else:
             self.value = val
+
+#==============================================================================
+class Aggregation(object):
+    #--------------------------------------------------------------------------
+    def __init__(self,
+                 name,
+                 aggregation_fn):
+
+
+    #--------------------------------------------------------------------------
+    def set_value(self, val):

--- a/configman/option.py
+++ b/configman/option.py
@@ -119,7 +119,10 @@ class Aggregation(object):
                  name,
                  aggregation_fn):
         self.name = name
-        self.aggregation_fn = aggregation_fn
+        if isinstance(aggregation_fn, basestring):
+            self.aggregation_fn = conv.class_converter(aggregation_fn)
+        else:
+            self.aggregation_fn = aggregation_fn
         self.value = None
 
     #--------------------------------------------------------------------------

--- a/configman/option.py
+++ b/configman/option.py
@@ -41,6 +41,7 @@ import collections
 import converters as conv
 from config_exceptions import CannotConvertError
 
+
 #==============================================================================
 class Option(object):
     #--------------------------------------------------------------------------
@@ -111,6 +112,7 @@ class Option(object):
             self.set_value(val["default"])
         else:
             self.value = val
+
 
 #==============================================================================
 class Aggregation(object):

--- a/configman/option.py
+++ b/configman/option.py
@@ -51,12 +51,14 @@ class Option(object):
                  from_string_converter=None,
                  value=None,
                  short_form=None,
+                 is_template=False,
                  *args,
                  **kwargs):
         self.name = name
         self.short_form = short_form
         self.default = default
         self.doc = doc
+        self.is_template = is_template
         if from_string_converter is None:
             if default is not None:
                 # take a qualified guess from the default value

--- a/configman/option.py
+++ b/configman/option.py
@@ -69,6 +69,10 @@ class Option(object):
 
         if value is None:
             value = default
+        if is_template:
+            self.value = default
+            return # we want to avoid calling the coverter on template
+                   # options until the very end
         self.set_value(value)
         if (type(self.value) != type(self.default)
             and self.from_string_converter):
@@ -101,6 +105,12 @@ class Option(object):
 
     #--------------------------------------------------------------------------
     def set_value(self, val):
+        if self.is_template:
+            return
+        self.do_set_value(val)
+
+    #--------------------------------------------------------------------------
+    def do_set_value(self, val):
         if isinstance(val, basestring):
             try:
                 self.value = self.from_string_converter(val)

--- a/configman/option.py
+++ b/configman/option.py
@@ -119,14 +119,14 @@ class Aggregation(object):
     #--------------------------------------------------------------------------
     def __init__(self,
                  name,
-                 aggregation_fn):
+                 function):
         self.name = name
-        if isinstance(aggregation_fn, basestring):
-            self.aggregation_fn = conv.class_converter(aggregation_fn)
+        if isinstance(function, basestring):
+            self.function = conv.class_converter(function)
         else:
-            self.aggregation_fn = aggregation_fn
+            self.function = function
         self.value = None
 
     #--------------------------------------------------------------------------
     def aggregate(self, all_options, local_namespace, args):
-        self.value = self.aggregation_fn(all_options, local_namespace, args)
+        self.value = self.function(all_options, local_namespace, args)

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -769,6 +769,7 @@ string =   from ini
         n.admin.add_option('application',
                            MyApp,
                            'the app object class')
+
         class MyConfigManager(config_manager.ConfigurationManager):
             def output_summary(inner_self):
                 output_stream = StringIO()
@@ -998,7 +999,6 @@ string =   from ini
                                          'argument 3'])
         self.assertEqual(c.print_conf_called, True)
 
-
     def test_non_compliant_app_object(self):
         # the MyApp class doesn't define required config
         class MyApp():
@@ -1023,11 +1023,12 @@ string =   from ini
                                                  'argument 2',
                                                  'argument 3'])
         conf = c.get_config()
-        self.assertEqual(conf.keys(), ['admin']) # there should be nothing but
-                                                 # the admin key
+        self.assertEqual(conf.keys(), ['admin'])  # there should be nothing but
+                                                  # the admin key
 
     def test_print_conf(self):
         n = config_manager.Namespace()
+
         class MyConfigManager(config_manager.ConfigurationManager):
             def __init__(inner_self, *args, **kwargs):
                 inner_self.write_called = False
@@ -1057,9 +1058,9 @@ string =   from ini
                                          'argument 3'],
                             config_pathname='fred')
 
-
     def test_dump_conf(self):
         n = config_manager.Namespace()
+
         class MyConfigManager(config_manager.ConfigurationManager):
             def __init__(inner_self, *args, **kwargs):
                 inner_self.write_called = False
@@ -1080,9 +1081,9 @@ string =   from ini
                                          'argument 3'],
                             config_pathname='fred')
 
-
     def test_config_pathname_set(self):
         n = config_manager.Namespace()
+
         class MyConfigManager(config_manager.ConfigurationManager):
             def __init__(inner_self, *args, **kwargs):
                 inner_self.write_called = False
@@ -1090,7 +1091,7 @@ string =   from ini
 
             def get_config_pathname(self):
                 temp_fn = os.path.isdir
-                os.path.isdir = lambda x : False
+                os.path.isdir = lambda x: False
                 try:
                     r = super(MyConfigManager, self).get_config_pathname()
                 finally:
@@ -1106,7 +1107,6 @@ string =   from ini
                                        'argument 2',
                                        'argument 3'],
                           config_pathname='fred')
-
 
     def test_ConfigurationManager_block_password(self):
         function = config_manager.ConfigurationManager.block_password
@@ -1166,5 +1166,3 @@ string =   from ini
         self.assertEqual(config.sub1.statement,
                          'wilma married fred using password @$*$&26Ht '
                          'but divorced because of arg2.')
-
-

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -1120,3 +1120,51 @@ string =   from ini
         self.assertEqual(function('foo', 'my_password', 'peter',
                                   block_password=True),
                          ('foo', 'my_password', '*********'))
+
+    def test_do_aggregations(self):
+        def aggregation_test(all_config, local_namespace, args):
+            self.assertTrue('password' in all_config)
+            self.assertTrue('sub1' in all_config)
+            self.assertTrue('name' in all_config.sub1)
+            self.assertTrue('name' in local_namespace)
+            self.assertTrue('spouse' in local_namespace)
+            self.assertEqual(len(args), 2)
+            return ('%s married %s using password %s but '
+                    'divorced because of %s.' % (local_namespace.name,
+                                                local_namespace.spouse,
+                                                all_config.password,
+                                                args[1]))
+
+        class MyApp(config_manager.RequiredConfig):
+            app_name = 'fred'
+            app_version = '1.0'
+            app_description = "my app"
+            required_config = config_manager.Namespace()
+            required_config.add_option('password', '@$*$&26Ht', 'the password')
+            required_config.namespace('sub1')
+            required_config.sub1.add_option('name', 'ethel', 'the name')
+            required_config.sub1.add_option('spouse', 'fred', 'the spouse')
+            required_config.sub1.add_aggregation('statement', aggregation_test)
+
+            def __init__(inner_self, config):
+                inner_self.config = config
+
+        n = config_manager.Namespace()
+        n.admin = config_manager.Namespace()
+        n.admin.add_option('application',
+                           MyApp,
+                           'the app object class')
+
+        c = config_manager.ConfigurationManager(n,
+                                                [getopt],
+                                    use_admin_controls=True,
+                                    use_auto_help=False,
+                                    argv_source=['--sub1.name=wilma',
+                                                 'arg1',
+                                                 'arg2'])
+        config = c.config
+        self.assertEqual(config.sub1.statement,
+                         'wilma married fred using password @$*$&26Ht '
+                         'but divorced because of arg2.')
+
+

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -79,7 +79,7 @@ class TestCase(unittest.TestCase):
           use_auto_help=False,
           argv_source=[]
         )
-        d = c.get_config()
+        d = c.config
         e = DotDict()
         e.a = 1
         e.b = 17
@@ -100,7 +100,7 @@ class TestCase(unittest.TestCase):
           use_auto_help=False,
           argv_source=[]
         )
-        d = c.get_config()
+        d = c.config
         e = DotDict()
         e.a = 1
         e.b = 17
@@ -185,7 +185,7 @@ class TestCase(unittest.TestCase):
                                     argv_source=[])
         o = {"a": 2, "c.z": 22, "c.x": 'noob', "c.y": "2.89"}
         c.overlay_config_recurse(o)
-        d = c.get_config()
+        d = c.generate_config()
         e = DotDict()
         e.a = 2
         e.b = 17
@@ -214,7 +214,7 @@ class TestCase(unittest.TestCase):
                                     argv_source=[])
         o = {"a": 2, "c.z": 22, "c.x": 'noob', "c.y": "2.89", "n": "not here"}
         c.overlay_config_recurse(o, ignore_mismatches=True)
-        d = c.get_config()
+        d = c.generate_config()
         e = DotDict()
         e.a = 2
         e.b = 17
@@ -1022,7 +1022,7 @@ string =   from ini
                                     argv_source=['argument 1',
                                                  'argument 2',
                                                  'argument 3'])
-        conf = c.get_config()
+        conf = c.config
         self.assertEqual(conf.keys(), ['admin'])  # there should be nothing but
                                                   # the admin key
 

--- a/configman/tests/test_val_for_json.py
+++ b/configman/tests/test_val_for_json.py
@@ -48,6 +48,8 @@ import configman.datetime_util as dtu
 from configman.value_sources.for_json import ValueSource
 #from ..value_sources.for_json import ValueSource
 
+def bbb_minus_one(config, local_config, args):
+    return config.bbb - 1
 
 class TestCase(unittest.TestCase):
 
@@ -106,6 +108,7 @@ class TestCase(unittest.TestCase):
           from_string_converter=int
         )
         n.add_option('write', 'json')
+        n.add_aggregation('bbb_minus_one', bbb_minus_one)
         #t = tempfile.NamedTemporaryFile('w', suffix='.json', delete=False)
         name = '/tmp/test.json'
         import functools
@@ -127,8 +130,10 @@ class TestCase(unittest.TestCase):
                                         use_admin_controls=True,
                                         use_auto_help=False,
                                         argv_source=[])
-            config = c2.get_config()
+            config = c2.config
             self.assertEqual(config.aaa, expected_date)
             self.assertEqual(config.bbb, -99)
+            self.assertEqual(config.bbb_minus_one, -100)
+
         finally:
             os.unlink(name)

--- a/configman/tests/test_val_for_json.py
+++ b/configman/tests/test_val_for_json.py
@@ -48,8 +48,10 @@ import configman.datetime_util as dtu
 from configman.value_sources.for_json import ValueSource
 #from ..value_sources.for_json import ValueSource
 
+
 def bbb_minus_one(config, local_config, args):
     return config.bbb - 1
+
 
 class TestCase(unittest.TestCase):
 

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -152,6 +152,7 @@ def write(file_name_extension,
                                                " name extension" %
                                                file_name_extension)
 
+
 def get_admin_options_from_command_line(config_manager):
     command_line_value_source = for_getopt.ValueSource(for_getopt.getopt,
                                                        config_manager)

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -139,7 +139,7 @@ class ValueSource(object):
                                      short_options_list,
                                      long_options_list):
         for key, val in source.items():
-            if type(val) == option.Option:
+            if isinstance(val, option.Option):
                 boolean_option = type(val.default) == bool
                 if val.short_form:
                     try:
@@ -156,6 +156,8 @@ class ValueSource(object):
                     long_options_list.append('%s%s' % (prefix, val.name))
                 else:
                     long_options_list.append('%s%s=' % (prefix, val.name))
+            elif isinstance(val, option.Aggregation):
+                pass # skip Aggregations they have nothing to do with getopt
             else:  # Namespace case
                 new_prefix = '%s%s.' % (prefix, key)
                 self.getopt_create_opts_recursive(val,

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -157,7 +157,7 @@ class ValueSource(object):
                 else:
                     long_options_list.append('%s%s=' % (prefix, val.name))
             elif isinstance(val, option.Aggregation):
-                pass # skip Aggregations they have nothing to do with getopt
+                pass  # skip Aggregations they have nothing to do with getopt
             else:  # Namespace case
                 new_prefix = '%s%s.' % (prefix, key)
                 self.getopt_create_opts_recursive(val,

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -42,6 +42,7 @@ import sys
 
 from .. import converters as conv
 from ..namespace import Namespace
+from ..option import Option, Aggregation
 
 from source_exceptions import (ValueException, NotEnoughInformationException,
                                NoHandlerForType)
@@ -103,10 +104,15 @@ class ValueSource(object):
             d = json_dict
             for x in qkey.split('.'):
                 d = d[x]
-            for okey, oval in val.__dict__.iteritems():
-                try:
-                    d[okey] = conv.to_string_converters[type(oval)](oval)
-                except KeyError:
-                    d[okey] = str(oval)
-            d['default'] = d['value']
+            if isinstance(val, Option):
+                for okey, oval in val.__dict__.iteritems():
+                    try:
+                        d[okey] = conv.to_string_converters[type(oval)](oval)
+                    except KeyError:
+                        d[okey] = str(oval)
+                d['default'] = d['value']
+            elif isinstance(val, Aggregation):
+                d['name'] = val.name
+                fn = val.aggregation_fn
+                d['aggregation_fn'] = conv.to_string_converters[type(fn)](fn)
         json.dump(json_dict, output_stream)

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -114,6 +114,6 @@ class ValueSource(object):
                 d['default'] = d['value']
             elif isinstance(val, Aggregation):
                 d['name'] = val.name
-                fn = val.aggregation_fn
-                d['aggregation_fn'] = conv.to_string_converters[type(fn)](fn)
+                fn = val.function
+                d['function'] = conv.to_string_converters[type(fn)](fn)
         json.dump(json_dict, output_stream)

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -64,12 +64,13 @@ class ValueSource(object):
         self.values = None
         if source is json:
             try:
-                app = the_config_manager.get_option_by_name('admin.application')
+                app = the_config_manager.get_option_by_name(
+                                                      'admin.application')
                 source = "%s.%s" % (app.value.app_name, file_name_extension)
             except (AttributeError, KeyError):
                 raise NotEnoughInformationException("Can't setup an json "
-                                                       "file without knowing "
-                                                       "the file name")
+                                                    "file without knowing "
+                                                    "the file name")
         if (isinstance(source, basestring) and
            source.endswith(file_name_extension)):
             try:

--- a/demo/demo1.py
+++ b/demo/demo1.py
@@ -92,7 +92,7 @@ c = cm.ConfigurationManager(definition_source,
                             app_description=__doc__)
 
 # fetch the DOM-like instance that gives access to the configuration info
-config = c.get_config()
+config = c.config
 
 # use the config
 if config.action == 'echo':

--- a/demo/demo1j.py
+++ b/demo/demo1j.py
@@ -79,7 +79,7 @@ c = cm.ConfigurationManager(definition_source,
                             app_description=__doc__)
 
 # fetch the DOM-like instance that gives access to the configuration info
-config = c.get_config()
+config = c.config
 
 # use the config
 if config.action == 'echo':

--- a/demo/demo2.py
+++ b/demo/demo2.py
@@ -121,7 +121,7 @@ c = cm.ConfigurationManager(definition_source,
                             app_description=__doc__)
 
 # fetch the DotDict version of the values
-config = c.get_config()
+config = c.config
 
 # use the config
 config.action(config.text)

--- a/demo/fakedb.py
+++ b/demo/fakedb.py
@@ -1,0 +1,42 @@
+# This is just a hack to simulate the minimal api of psycopg2 for the purposes
+# of a demo.  There is nothing of any real interest here, please move along.
+
+class FakeDatabaseObjects(object):
+    # This class provides an interface to a fake relational database
+    # loosely modeled after the psycopg2 library.  It actually does nothing
+    # at all execept offer an API and track if it is in a transaction or not.
+    in_transaction = 0
+    @staticmethod
+    def connect(dsn):
+        print 'connnected to database with "%s"' % dsn
+        FakeDatabaseObjects.in_transaction = 1
+        return FakeDatabaseObjects
+
+    @staticmethod
+    def cursor():
+        print 'new cursor created'
+        return FakeDatabaseObjects
+
+    @staticmethod
+    def execute(sql):
+        print 'executing: "%s"' % sql
+
+    @staticmethod
+    def close():
+        print 'closing connection'
+
+    @staticmethod
+    def commit():
+        FakeDatabaseObjects.in_transaction = 0
+        print 'commiting transaction'
+
+    @staticmethod
+    def rollback():
+        FakeDatabaseObjects.in_transaction = 0
+        print 'rolling back transaction'
+
+    @staticmethod
+    def get_transaction_status():
+        return FakeDatabaseObjects.in_transaction
+
+    STATUS_IN_TRANSACTION = 1

--- a/demo/fakedb.py
+++ b/demo/fakedb.py
@@ -1,6 +1,7 @@
 # This is just a hack to simulate the minimal api of psycopg2 for the purposes
 # of a demo.  There is nothing of any real interest here, please move along.
 
+
 class FakeDatabaseObjects(object):
     # This class provides an interface to a fake relational database
     # loosely modeled after the psycopg2 library.  It actually does nothing

--- a/demo/fakedb.py
+++ b/demo/fakedb.py
@@ -6,6 +6,7 @@ class FakeDatabaseObjects(object):
     # loosely modeled after the psycopg2 library.  It actually does nothing
     # at all execept offer an API and track if it is in a transaction or not.
     in_transaction = 0
+
     @staticmethod
     def connect(dsn):
         print 'connnected to database with "%s"' % dsn

--- a/demo/generic_app.py
+++ b/demo/generic_app.py
@@ -93,7 +93,7 @@ def main(app_object=None):
                                              app_version=app_version,
                                              app_description=app_description,
                                             )
-    config = config_manager.get_config()
+    config = config_manager.config
 
     app_object = config.admin.application
 

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -24,8 +24,6 @@ def transaction_context_factory(config_unused, local_namespace, args_unused):
         conn = FakeDatabaseObjects.connect(dsn)
         try:
             yield conn
-        except Exception, x:
-            raise x
         finally:
             status = conn.get_transaction_status()
             if status == FakeDatabaseObjects.STATUS_IN_TRANSACTION:

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -62,8 +62,8 @@ def define_config():
       short_form='p'
     )
     # This final aggregation object is the most interesting one.  Its final
-    # value depends on the final values of the options within the same
-    # Namespace.  After configman is done doing all its overlays, there is
+    # value depends on the final values of options within the same Namespace.
+    # After configman is done doing all its value overlays, there is
     # one final pass through the option definitions with the sole purpose of
     # expanding the Aggregations.  To do so, the Aggregations' aggregation_fn
     # is called passing the whole config set to the function.  That function
@@ -84,9 +84,10 @@ if __name__ == '__main__':
     config = config_manager.get_config()
 
     # In this example we do two transactions.
-    # This first one succeeds because we called the 'commit' function.
-    # The actions are logged to stdout, you can see that connection opens,
-    # some actions happen, the transaction commits and the connection
+    # This first one succeeds so we call the 'commit' function to indicate
+    # that fact.  The actions in the database are logged to stdout, you can
+    # see the order of events: connection opens, we fetch a cursor, we execute
+    # some sql, we commit the transaction and the connection
     # is automatically closed
     try:
         with config.db_transaction() as dbconn:
@@ -96,10 +97,10 @@ if __name__ == '__main__':
     except Exception, x:
         print str(x)
 
-    # This second transaction fails with an exception raised.  Because no
-    # commit was called during the context of the 'with' statement, the
-    # transaction will be automatically rolled back.  This behavior is shown
-    # in the stdout logging when the app is run.
+    # This second transaction fails with a (contrived) exception being raised.
+    # Because no commit was called during the context of the 'with' statement,
+    # the transaction will be automatically rolled back. This behavior is shown
+    # in the stdout logging when the app is run:
     try:
         with config.db_transaction() as dbconn:
             cursor = dbconn.cursor()

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -1,11 +1,19 @@
+#!/usr/bin/env python
 import contextlib
 
 from configman import Namespace, ConfigurationManager
 
 class FakeDatabaseObjects(object):
+    # This class provides an interface to a fake relational database
+    # loosely modeled after the psycopg2 library.  It actually does nothing
+    # at all execept offer an API and track if it is in a transaction or not.
+    # It can be ignored as it is just support for the more interesting
+    # example code that follows
+    in_transaction = 0
     @staticmethod
-    def connection(dsn):
+    def connect(dsn):
         print 'connnected to database with "%s"' % dsn
+        FakeDatabaseObjects.in_transaction = 1
         return FakeDatabaseObjects
 
     @staticmethod
@@ -23,27 +31,39 @@ class FakeDatabaseObjects(object):
 
     @staticmethod
     def commit():
+        FakeDatabaseObjects.in_transaction = 0
         print 'commiting transaction'
 
     @staticmethod
     def rollback():
+        FakeDatabaseObjects.in_transaction = 0
         print 'rolling back transaction'
 
+    @staticmethod
+    def get_transaction_status():
+        return FakeDatabaseObjects.in_transaction
 
-def transaction_context_factory(dsn_dict):
-    dsn = ("host=%(host)s "
-           "dbname=%(dbname)s "
-           "user=%(user)s "
-           "password=%(password)s") % dsn_dict
+    STATUS_IN_TRANSACTION = 1
+
+# this is the interesting function in this example.  It is used as a
+# from string converter.  It takes a database connection string (DSN)
+# and emits a fuction that returns a database connection object wrapped
+# in a contextmanager.  This allows a configuration value to serve as a
+# factory for database transaction objects suitable for use in a 'with'
+# statement.
+def transaction_context_factory(dsn):
     @contextlib.contextmanager
     def transaction_context():
         conn = FakeDatabaseObjects.connect(dsn)
         yield conn
         status = conn.get_transaction_status()
-        if status == psycopg2.extensions.STATUS_IN_TRANSACTION:
+        if status == FakeDatabaseObjects.STATUS_IN_TRANSACTION:
             conn.rollback()
         conn.close()
+    return transaction_context
 
+# this function defines the connection parameters required to connect to
+# a database.
 def define_config():
     definition = Namespace()
     definition.add_option(
@@ -56,25 +76,37 @@ def define_config():
       name='dbname',
       default='',
       doc='the name of the database',
-      short_form='n'
+      short_form='d'
     )
     definition.add_option(
       name='user',
       default='',
       doc='the name of the user within the database',
-      short_form='n'
+      short_form='u'
     )
     definition.add_option(
       name='password',
       default='',
       doc='the name of the database',
-      short_form='n'
+      short_form='p'
     )
+    dsn_template = ("host=%(host)s "
+                    "dbname=%(dbname)s "
+                    "user=%(user)s "
+                    "password=%(password)s")
+    # This final option is the most interesting one.  Note that it is marked
+    # as a template option.  That means that its value depends on the final
+    # values of the other options within the same Namespace.  After configman
+    # is done making all its overlays, there is one final pass through the
+    # option definitions with the sole purpose of expanding these templated
+    # values.  Just like other options, once it has its final value, the
+    # from_string_converter is applied.  In this case, the coverter is the
+    # database transaction factory function from above.
     definition.add_option(
       name='transaction_context',
-      default=dsn_dict,
+      default=dsn_template,
       from_string_converter=transaction_context_factory,
-      template=True
+      is_template=True
     )
     return definition
 
@@ -84,32 +116,23 @@ if __name__ == '__main__':
     config_manager = ConfigurationManager(definition)
     config = config_manager.get_config()
 
-    with config.transaction_context() as dbconn:
-        cursor = dbconn.cursor()
-        cursor.execute('select * from pg_tables')
-        dbconn.commit()
+    # In this example we do two transactions.
+    # This first one succeeds because we called the 'commit' function.
+    # The actions are logged to stdout, you can see that connection opens,
+    # some actions happen, the transaction commits and the connection
+    # is automatically closed
+    try:
+        with config.transaction_context() as dbconn:
+            cursor = dbconn.cursor()
+            cursor.execute('select * from pg_tables')
+            dbconn.commit()
+    except Exception, x:
+        print str(x)
 
-    with config.transaction_context() as dbconn:
-        cursor = dbconn.cursor()
-        cursor.execute('select * from pg_tables')
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-self.dsn = "host=%(databaseHost)s port=%(databasePort)s dbname=%(databaseName)s user=%(databaseUserName)s password=%(databasePassword)s" % config
+    try:
+        with config.transaction_context() as dbconn:
+            cursor = dbconn.cursor()
+            cursor.execute('select * from pg_tables')
+            raise Exception("we failed for some reason")
+    except Exception, x:
+        print str(x)

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -76,7 +76,7 @@ def define_config():
     # contextmanagers.
     definition.add_aggregation(
       name='db_transaction',
-      aggregation_fn=transaction_context_factory
+      function=transaction_context_factory
     )
     return definition
 
@@ -93,10 +93,10 @@ if __name__ == '__main__':
     # some sql, we commit the transaction and the connection
     # is automatically closed
     try:
-        with config.db_transaction() as dbconn:
-            cursor = dbconn.cursor()
+        with config.db_transaction() as transaction:
+            cursor = transaction.cursor()
             cursor.execute('select * from pg_tables')
-            dbconn.commit()
+            transaction.commit()
     except Exception, x:
         print str(x)
 
@@ -105,8 +105,8 @@ if __name__ == '__main__':
     # the transaction will be automatically rolled back. This behavior is shown
     # in the stdout logging when the app is run:
     try:
-        with config.db_transaction() as dbconn:
-            cursor = dbconn.cursor()
+        with config.db_transaction() as transaction:
+            cursor = transaction.cursor()
             cursor.execute('select * from pg_tables')
             raise Exception("we failed for some reason")
     except Exception, x:

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -84,7 +84,7 @@ def define_config():
 if __name__ == '__main__':
     definition = define_config()
     config_manager = ConfigurationManager(definition)
-    config = config_manager.get_config()
+    config = config_manager.config
 
     # In this example we do two transactions.
     # This first one succeeds so we call the 'commit' function to indicate

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -5,6 +5,7 @@ from configman import Namespace, ConfigurationManager
 
 from fakedb import FakeDatabaseObjects
 
+
 # this is the interesting function in this example.  It is used as a
 # from aggregation function for an Aggregation object that live within a
 # configman's option definition.  It takes a database connection string (DSN)
@@ -17,6 +18,7 @@ def transaction_context_factory(config_unused, local_namespace, args_unused):
            "dbname=%(dbname)s "
            "user=%(user)s "
            "password=%(password)s") % local_namespace
+
     @contextlib.contextmanager
     def transaction_context():
         conn = FakeDatabaseObjects.connect(dsn)
@@ -30,6 +32,7 @@ def transaction_context_factory(config_unused, local_namespace, args_unused):
                 conn.rollback()
             conn.close()
     return transaction_context
+
 
 # this function defines the connection parameters required to connect to
 # a database.

--- a/demo/trans_generator.py
+++ b/demo/trans_generator.py
@@ -1,0 +1,115 @@
+import contextlib
+
+from configman import Namespace, ConfigurationManager
+
+class FakeDatabaseObjects(object):
+    @staticmethod
+    def connection(dsn):
+        print 'connnected to database with "%s"' % dsn
+        return FakeDatabaseObjects
+
+    @staticmethod
+    def cursor():
+        print 'new cursor created'
+        return FakeDatabaseObjects
+
+    @staticmethod
+    def execute(sql):
+        print 'executing: "%s"' % sql
+
+    @staticmethod
+    def close():
+        print 'closing connection'
+
+    @staticmethod
+    def commit():
+        print 'commiting transaction'
+
+    @staticmethod
+    def rollback():
+        print 'rolling back transaction'
+
+
+def transaction_context_factory(dsn_dict):
+    dsn = ("host=%(host)s "
+           "dbname=%(dbname)s "
+           "user=%(user)s "
+           "password=%(password)s") % dsn_dict
+    @contextlib.contextmanager
+    def transaction_context():
+        conn = FakeDatabaseObjects.connect(dsn)
+        yield conn
+        status = conn.get_transaction_status()
+        if status == psycopg2.extensions.STATUS_IN_TRANSACTION:
+            conn.rollback()
+        conn.close()
+
+def define_config():
+    definition = Namespace()
+    definition.add_option(
+      name='host',
+      default='localhost',
+      doc='the hostname of the database',
+      short_form='h'
+    )
+    definition.add_option(
+      name='dbname',
+      default='',
+      doc='the name of the database',
+      short_form='n'
+    )
+    definition.add_option(
+      name='user',
+      default='',
+      doc='the name of the user within the database',
+      short_form='n'
+    )
+    definition.add_option(
+      name='password',
+      default='',
+      doc='the name of the database',
+      short_form='n'
+    )
+    definition.add_option(
+      name='transaction_context',
+      default=dsn_dict,
+      from_string_converter=transaction_context_factory,
+      template=True
+    )
+    return definition
+
+
+if __name__ == '__main__':
+    definition = define_config()
+    config_manager = ConfigurationManager(definition)
+    config = config_manager.get_config()
+
+    with config.transaction_context() as dbconn:
+        cursor = dbconn.cursor()
+        cursor.execute('select * from pg_tables')
+        dbconn.commit()
+
+    with config.transaction_context() as dbconn:
+        cursor = dbconn.cursor()
+        cursor.execute('select * from pg_tables')
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+self.dsn = "host=%(databaseHost)s port=%(databasePort)s dbname=%(databaseName)s user=%(databaseUserName)s password=%(databasePassword)s" % config

--- a/demo/tutorial02.py
+++ b/demo/tutorial02.py
@@ -22,7 +22,7 @@ def define_config():
 if __name__ == '__main__':
     definition = define_config()
     config_manager = ConfigurationManager(definition)
-    config = config_manager.get_config()
+    config = config_manager.config
     output_string = ' '.join(config_manager.args)
     if config.devowel:
         output_string = devowel(output_string)

--- a/demo/tutorial03.py
+++ b/demo/tutorial03.py
@@ -30,7 +30,7 @@ def define_config():
 if __name__ == '__main__':
     definition = define_config()
     config_manager = ConfigurationManager(definition)
-    config = config_manager.get_config()
+    config = config_manager.config
     if config.file:
         with open(config.file) as f:
             output_string = f.read().strip()

--- a/demo/tutorial04.py
+++ b/demo/tutorial04.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     value_sources = ('./backwards.ini', os.environ, getopt)
     config_manager = ConfigurationManager(definition,
                                           values_source_list=value_sources)
-    config = config_manager.get_config()
+    config = config_manager.config
     if config.file:
         with open(config.file) as f:
             output_string = f.read().strip()

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -78,7 +78,7 @@ us correctly::
 
  ...
  config_manager = ConfigurationManager(definition)
- config = config_manager.get_config()
+ config = config_manager.config
 
 That's all! That last line returned an instance of what we call a DotDict.
 It is essentially a standard Python dict that's had its ``__getattr__`` cross
@@ -108,7 +108,7 @@ of ``devowel`` in the full example below::
  if __name__ == '__main__':
      definition = define_config()
      config_manager = ConfigurationManager(definition)
-     config = config_manager.get_config()
+     config = config_manager.config
      output_string = ' '.join(config_manager.args)
      if config.devowel:
          output_string = devowel(output_string)
@@ -202,7 +202,7 @@ Excellent! The whole thing together looks like this now::
  if __name__ == '__main__':
      definition = define_config()
      config_manager = ConfigurationManager(definition)
-     config = config_manager.get_config()
+     config = config_manager.config
      if config.file:
          with open(config.file) as f:
              output_string = f.read().strip()


### PR DESCRIPTION
This is the implementation of a proposal to add aggregations to configman.   The idea is to add meta entries to the configuration that are aggregations of other entries.  Aggregations are comprised of a name and a function that returns the aggregation value.  The function must accept three parameters and can return any type of object: 

1) a dict that represents the whole configuration (the output of config.get_config())
2) a dict that represents the local config (the namespace in which the aggregation object lives)
3) a list of command line arguments (those that are not associated with command line switches)

This concept came from a desire to create factory objects in configuration that require input from more than one configuration option.  See .../demo/trans_generator.py for an example of a really cool database transaction factory using this idea.
