### PR TITLE
fix Aggregation behavior for config files

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -383,8 +383,12 @@ class ConfigurationManager(object):
             if isinstance(sub_destination, Namespace):
                 self.overlay_config_recurse(val, sub_destination,
                                             prefix=('%s.%s' % (prefix, key)))
-            else:
+            elif isinstance(sub_destination, Option):
                 sub_destination.set_value(val)
+            elif isinstance(sub_destination, Aggregation):
+                # there is nothing to do for Aggregations at this time
+                # it appears here anyway as a marker for future enhancements
+                pass
 
     #--------------------------------------------------------------------------
     def walk_config_copy_values(self, source, destination):

--- a/configman/value_sources/for_conf.py
+++ b/configman/value_sources/for_conf.py
@@ -47,6 +47,7 @@ to open it.
 import functools
 import sys
 
+from .. import namespace
 from .. import option as opt
 from .. import converters as conv
 
@@ -115,7 +116,10 @@ class ValueSource(object):
     @staticmethod
     def write(option_iter, output_stream=sys.stdout, comments=True):
         for qkey, key, val in option_iter():
-            if isinstance(val, opt.Option):
+            if isinstance(val, namespace.Namespace):
+                print >> output_stream, '#%s' % ('-' * 79)
+                print >> output_stream, '# %s - %s\n' % (key, val._doc)
+            elif isinstance(val, opt.Option):
                 if comments:
                     print >> output_stream, '# name:', qkey
                     print >> output_stream, '# doc:', val.doc
@@ -123,6 +127,7 @@ class ValueSource(object):
                         conv.py_obj_to_str(val.from_string_converter)
                 val_str = conv.option_value_str(val)
                 print >> output_stream, '%s=%s\n' % (qkey, val_str)
-            else:
-                print >> output_stream, '#%s' % ('-' * 79)
-                print >> output_stream, '# %s - %s\n' % (key, val._doc)
+            elif isinstance(val, opt.Aggregation):
+                # there is nothing to do for Aggregations at this time
+                # it appears here anyway as a marker for future enhancements
+                pass

--- a/configman/value_sources/for_configparse.py
+++ b/configman/value_sources/for_configparse.py
@@ -42,6 +42,7 @@ import ConfigParser
 from source_exceptions import (CantHandleTypeException, ValueException,
                                NotEnoughInformationException)
 from .. import namespace
+from .. import option
 from .. import converters as conv
 
 
@@ -135,10 +136,14 @@ class ValueSource(object):
             if isinstance(val, namespace.Namespace):
                 print >> output_stream, '[%s]' % key
                 print >> output_stream, '# %s\n' % val._doc
-            else:
+            elif isinstance(val, option.Option):
                 print >> output_stream, '# name:', qkey
                 print >> output_stream, '# doc:', val.doc
                 print >> output_stream, '# converter:', \
                    conv.py_obj_to_str(val.from_string_converter)
                 val_str = conv.option_value_str(val)
                 print >> output_stream, '%s=%s\n' % (key, val_str)
+            elif isinstance(val, opt.Aggregation):
+                # there is nothing to do for Aggregations at this time
+                # it appears here anyway as a marker for future enhancements
+                pass


### PR DESCRIPTION
The values of Aggregations always depend on a function on a set of Options.  Therefore they should not appear in the ini and conf configuration files.  Since json files can be used as a definition source, Aggregations are appropriate there, but they should never be used as a value source. 

This fixes both problems by making sure that whenever the Option definition tree is walked, Aggregations are ignored at the proper time.

This patch also includes a minor bit of code rearrangement so that each of the similar code sections deal with the Options, Aggregations and Namespaces in the same order.
