### PR TITLE
divided config_manager methods by public/private

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -182,9 +182,9 @@ class ConfigurationManager(object):
         self.options_banned_from_help = options_banned_from_help
 
         if use_auto_help:
-            self.setup_auto_help()
+            self._setup_auto_help()
         if use_admin_controls:
-            admin_options = self.setup_admin_options(values_source_list)
+            admin_options = self._setup_admin_options(values_source_list)
             self.definition_source_list.append(admin_options)
 
         # iterate through the option definitions to create the nested dict
@@ -199,24 +199,24 @@ class ConfigurationManager(object):
             admin_options = value_sources.get_admin_options_from_command_line(
                                                                           self)
             # integrate the admin_options with 'option_definitions'
-            self.overlay_config_recurse(source=admin_options,
+            self._overlay_value_sources_recurse(source=admin_options,
                                         ignore_mismatches=True)
 
         self.values_source_list = value_sources.wrap(values_source_list,
                                                      self)
 
         # first pass to get classes & config path - ignore bad options
-        self.overlay_settings(ignore_mismatches=True)
+        self._overlay_value_sources(ignore_mismatches=True)
 
         # walk tree expanding class options
-        self.walk_expanding_class_options()
+        self._walk_expanding_class_options()
 
         # the app_name, app_version and app_description are to come from
         # if 'admin.application' option if it is present. If it is not present,
         # get the app_name,et al, from parameters passed into the constructor.
         # if those are empty, set app_name, et al, to empty strings
         try:
-            app_option = self.get_option_by_name('admin.application')
+            app_option = self._get_option('admin.application')
             self.app_name = getattr(app_option.value, 'app_name', '')
             self.app_version = getattr(app_option.value, 'app_version', '')
             self.app_description = getattr(app_option.value,
@@ -227,285 +227,53 @@ class ConfigurationManager(object):
             pass
 
         # second pass to include config file values - ignore bad options
-        self.overlay_settings(ignore_mismatches=True)
+        self._overlay_value_sources(ignore_mismatches=True)
 
         # walk tree expanding class options
-        self.walk_expanding_class_options()
+        self._walk_expanding_class_options()
 
         # third pass to get values - complain about bad options
-        self.overlay_settings(ignore_mismatches=False)
+        self._overlay_value_sources(ignore_mismatches=False)
 
-        if use_auto_help and self.get_option_by_name('help').value:
+        if use_auto_help and self._get_option('help').value:
             self.output_summary()
             admin_tasks_done = True
 
         if (use_admin_controls
-            and self.get_option_by_name('admin.print_conf').value):
+            and self._get_option('admin.print_conf').value):
             self.print_conf()
             admin_tasks_done = True
 
         if (use_admin_controls
-            and self.get_option_by_name('admin.dump_conf').value):
+            and self._get_option('admin.dump_conf').value):
             self.dump_conf()
             admin_tasks_done = True
 
         if quit_after_admin and admin_tasks_done:
             sys.exit()
 
-        self.aggregate()
+        self._aggregate()
 
     #--------------------------------------------------------------------------
     @property
     def config(self):
         if self._config is None:
-            self._config = self.generate_config()
+            self._config = self._generate_config()
         return self._config
-
-    #--------------------------------------------------------------------------
-    def generate_config(self):
-        """This routine generates a copy of the DotDict based config"""
-        config = DotDict()
-        self.walk_config_copy_values(self.option_definitions, config)
-        return config
-
-    #--------------------------------------------------------------------------
-    def walk_expanding_class_options(self, source_namespace=None,
-                                     parent_namespace=None):
-        if source_namespace is None:
-            source_namespace = self.option_definitions
-        expanded_keys = []
-        expansions_were_done = True
-        while expansions_were_done:
-            expansions_were_done = False
-            # can't use iteritems in loop, we're changing the dict
-            for key, val in source_namespace.items():
-                if isinstance(val, Namespace):
-                    self.walk_expanding_class_options(source_namespace=val,
-                                            parent_namespace=source_namespace)
-                elif (key not in expanded_keys and
-                        (inspect.isclass(val.value) or
-                         inspect.ismodule(val.value))):
-                    expanded_keys.append(key)
-                    expansions_were_done = True
-                    if key == 'application':
-                        target_namespace = parent_namespace
-                    else:
-                        target_namespace = source_namespace
-                    try:
-                        for o_key, o_val in \
-                                val.value.get_required_config().iteritems():
-                            target_namespace.__setattr__(o_key, o_val)
-                    except AttributeError:
-                        pass  # there are no required_options for this class
-                else:
-                    pass  # don't need to touch other types of Options
-            self.overlay_settings(ignore_mismatches=True)
-
-    #--------------------------------------------------------------------------
-    def setup_auto_help(self):
-        help_option = Option(name='help', doc='print this', default=False)
-        self.definition_source_list.append({'help': help_option})
-
-    #--------------------------------------------------------------------------
-    def get_config_pathname(self):
-        if os.path.isdir(self.config_pathname):
-            # we've got a path with no file name at the end
-            # use the appname as the file name and default to an 'ini'
-            # config file type
-            if self.app_name:
-                return os.path.join(self.config_pathname,
-                                    '%s.ini' % self.app_name)
-            else:
-                # there is no app_name yet
-                # we'll punt and use 'config'
-                return os.path.join(self.config_pathname, 'config.ini')
-        return self.config_pathname
-
-    #--------------------------------------------------------------------------
-    def setup_admin_options(self, values_source_list):
-        base_namespace = Namespace()
-        base_namespace.admin = admin = Namespace()
-        admin.add_option(name='print_conf',
-                         default=None,
-                         doc='write current config to stdout '
-                             '(conf, ini, json)',
-                         )
-        admin.add_option(name='dump_conf',
-                         default='',
-                         doc='a pathname to which to write the current config',
-                         )
-        # only offer the config file admin options if they've been requested in
-        # the values source list
-        if ConfigFileFutureProxy in values_source_list:
-            default_config_pathname = self.get_config_pathname()
-            admin.add_option(name='conf',
-                             default=default_config_pathname,
-                             doc='the pathname of the config file '
-                                 '(path/filename)',
-                             )
-        return base_namespace
-
-    #--------------------------------------------------------------------------
-    def overlay_settings(self, ignore_mismatches=True):
-        for a_settings_source in self.values_source_list:
-            try:
-                this_source_ignore_mismatches = (ignore_mismatches or
-                                    a_settings_source.always_ignore_mismatches)
-            except AttributeError:
-                # the settings source doesn't have the concept of always
-                # ignoring mismatches, so the original value of
-                # ignore_mismatches stands
-                this_source_ignore_mismatches = ignore_mismatches
-            options = a_settings_source.get_values(self,
-                            ignore_mismatches=this_source_ignore_mismatches)
-            self.overlay_config_recurse(options,
-                            ignore_mismatches=this_source_ignore_mismatches)
-
-    #--------------------------------------------------------------------------
-    def overlay_config_recurse(self, source, destination=None, prefix='',
-                                ignore_mismatches=True):
-        if destination is None:
-            destination = self.option_definitions
-        for key, val in source.items():
-            try:
-                sub_destination = destination
-                for subkey in key.split('.'):
-                    sub_destination = sub_destination[subkey]
-            except KeyError:
-                if ignore_mismatches:
-                    continue
-                if key == subkey:
-                    raise exc.NotAnOptionError('%s is not an option' % key)
-                raise exc.NotAnOptionError('%s subpart %s is not an option' %
-                                       (key, subkey))
-            except TypeError:
-                pass
-            if isinstance(sub_destination, Namespace):
-                self.overlay_config_recurse(val, sub_destination,
-                                            prefix=('%s.%s' % (prefix, key)))
-            elif isinstance(sub_destination, Option):
-                sub_destination.set_value(val)
-            elif isinstance(sub_destination, Aggregation):
-                # there is nothing to do for Aggregations at this time
-                # it appears here anyway as a marker for future enhancements
-                pass
-
-    #--------------------------------------------------------------------------
-    def walk_config_copy_values(self, source, destination):
-        for key, val in source.items():
-            value_type = type(val)
-            if isinstance(val, Option) or isinstance(val, Aggregation):
-                destination[key] = val.value
-            elif value_type == Namespace:
-                destination[key] = d = DotDict()
-                self.walk_config_copy_values(val, d)
-
-    #--------------------------------------------------------------------------
-    def aggregate(self, source=None, local_namespace=None):
-        if source is None:
-            source = self.option_definitions
-            local_namespace = self.config
-        for key, val in source.items():
-            if isinstance(val, Namespace):
-                self.aggregate(val, local_namespace[key])
-            elif isinstance(val, Aggregation):
-                val.aggregate(self.config, local_namespace, self.args)
-                self._config = None
-            # skip Options, we're only dealing with Aggregations
-
-    #--------------------------------------------------------------------------
-    @staticmethod
-    def option_sort(x_tuple):
-        key, val = x_tuple
-        if isinstance(val, Namespace):
-            return 'zzzzzzzzzzz%s' % key
-        else:
-            return key
-
-    #--------------------------------------------------------------------------
-    @staticmethod
-    def block_password(qkey, key, value, block_password=True):
-        if block_password and 'password' in key.lower():
-            value = '*********'
-        return qkey, key, value
-
-    #--------------------------------------------------------------------------
-    def walk_config(self, source=None, prefix='', blocked_keys=[],
-                    block_password=False):
-        if source == None:
-            source = self.option_definitions
-        options_list = source.items()
-        options_list.sort(key=ConfigurationManager.option_sort)
-        for key, val in options_list:
-            qualified_key = '%s%s' % (prefix, key)
-            if qualified_key in blocked_keys:
-                continue
-            if isinstance(val, Option):
-                yield self.block_password(qualified_key, key, val,
-                                          block_password)
-            if isinstance(val, Aggregation):
-                yield qualified_key, key, val
-            elif isinstance(val, Namespace):
-                if qualified_key == 'admin':
-                    continue
-                yield qualified_key, key, val
-                new_prefix = '%s%s.' % (prefix, key)
-                for xqkey, xkey, xval in self.walk_config(val,
-                                                          new_prefix,
-                                                          blocked_keys,
-                                                          block_password):
-                    yield xqkey, xkey, xval
-
-    #--------------------------------------------------------------------------
-    def get_option_by_name(self, name):
-        source = self.option_definitions
-        try:
-            for sub_name in name.split('.'):
-                candidate = source[sub_name]
-                if isinstance(candidate, Option):
-                    return candidate
-                else:
-                    source = candidate
-        except KeyError:
-            pass  # we need to raise the exception below in either case
-                  # of a key error or execution falling through the loop
-        raise exc.NotAnOptionError('%s is not a known option name' % name)
-
-    #--------------------------------------------------------------------------
-    def get_option_names(self, source=None, names=None, prefix=''):
-        if not source:
-            source = self.option_definitions
-        if names is None:
-            names = []
-        for key, val in source.items():
-            if isinstance(val, Namespace):
-                new_prefix = '%s%s.' % (prefix, key)
-                self.get_option_names(val, names, new_prefix)
-            elif isinstance(val, Option):
-                names.append("%s%s" % (prefix, key))
-            # skip aggregations, we want only Options
-        return names
-
-    #--------------------------------------------------------------------------
-    def get_options(self, source=None, options=None, prefix=''):
-        if not source:
-            source = self.option_definitions
-        if options is None:
-            options = []
-        for key, val in source.items():
-            if isinstance(val, Namespace):
-                new_prefix = '%s%s.' % (prefix, key)
-                self.get_options(val, options, new_prefix)
-            else:
-                options.append(("%s%s" % (prefix, key), val))
-        return options
 
     #--------------------------------------------------------------------------
     def output_summary(self,
                        output_stream=sys.stdout,
                        block_password=True):
         """outputs a usage tip and the list of acceptable commands.
-        This is useful as the output of the 'help' option or usage.
+        This is useful as the output of the 'help' option.
+
+        parameters:
+            output_stream - an open file-like object suitable for use as the
+                            target of a print statement
+            block_password - a boolean driving the use of a string of * in
+                             place of the value for any object containing the
+                             substring 'passowrd'
         """
         if self.app_name or self.app_description:
             print >> output_stream, 'Application:',
@@ -524,7 +292,7 @@ class ConfigurationManager(object):
         for name in names_list:
             if name in self.options_banned_from_help:
                 continue
-            option = self.get_option_by_name(name)
+            option = self._get_option(name)
 
             line = ' ' * 2  # always start with 2 spaces
             if option.short_form:
@@ -554,7 +322,15 @@ class ConfigurationManager(object):
 
     #--------------------------------------------------------------------------
     def print_conf(self):
-        config_file_type = self.get_option_by_name('admin.print_conf').value
+        """write a config file to the pathname specified in the parameter.  The
+        file extention determines the type of file written and must match a
+        registered type.
+
+        parameters:
+            config_pathname - the full path and filename of the target config
+                               file."""
+
+        config_file_type = self._get_option('admin.print_conf').value
 
         @contextlib.contextmanager
         def stdout_opener():
@@ -562,15 +338,34 @@ class ConfigurationManager(object):
         self.write_conf(config_file_type, stdout_opener)
 
     #--------------------------------------------------------------------------
-    def dump_conf(self):
-        config_pathname = self.get_option_by_name('admin.dump_conf').value
+    def dump_conf(self, config_pathname=None):
+        """write a config file to the pathname specified in the parameter.  The
+        file extention determines the type of file written and must match a
+        registered type.
+
+        parameters:
+            config_pathname - the full path and filename of the target config
+                               file."""
+
+        if not config_pathname:
+            config_pathname = self._get_option('admin.dump_conf').value
+
         opener = functools.partial(open, config_pathname, 'w')
         config_file_type = os.path.splitext(config_pathname)[1][1:]
         self.write_conf(config_file_type, opener)
 
     #--------------------------------------------------------------------------
     def write_conf(self, config_file_type, opener=open):
-        option_iterator = functools.partial(self.walk_config,
+        """write a configuration file to a file-like object.
+
+        parameters:
+            config_file_type - a string containing a registered file type.
+                               Passing in an unregistered string will result in
+                               a KeyError exception
+            opener - a callable object or function that returns a file like
+                     object that works as a context in a with statement."""
+
+        option_iterator = functools.partial(self._walk_config,
                                        blocked_keys=self.admin_controls_list)
         with opener() as config_fp:
             value_sources.write(config_file_type,
@@ -579,11 +374,17 @@ class ConfigurationManager(object):
 
     #--------------------------------------------------------------------------
     def log_config(self, logger):
+        """write out the current configuration to a log-like object.
+
+        parameters:
+            logger - a object that implements a method called 'info' with the
+                     same semantics as the call to 'logger.info'"""
+
         logger.info("app_name: %s", self.app_name)
         logger.info("app_version: %s", self.app_version)
         logger.info("current configuration:")
         config = [(qkey, val.value) for qkey, key, val in
-                                      self.walk_config(self.option_definitions)
+                                    self._walk_config(self.option_definitions)
                                     if qkey not in self.admin_controls_list
                                        and not isinstance(val, Namespace)]
         config.sort()
@@ -596,3 +397,256 @@ class ConfigurationManager(object):
                                 conv.to_string_converters[type(key)](val))
                 except KeyError:
                     logger.info('%s: %s', key, val)
+
+    #--------------------------------------------------------------------------
+    def get_option_names(self, source=None, names=None, prefix=''):
+        """returns a list of fully qualified option names.
+
+        parameters:
+            source - a sequence of Namespace of Options, usually not specified,
+                     If not specified, the function will default to using the
+                     internal list of Option definitions.
+            names - a list to start with for appending the lsit Option names.
+                    If ommited, the function will start with an empty list.
+
+        returns:
+            a list of strings representing the Options in the source Namespace
+            list.  Each item will be fully qualified with dot delimited
+            Namespace names.
+        """
+        if not source:
+            source = self.option_definitions
+        if names is None:
+            names = []
+        for key, val in source.items():
+            if isinstance(val, Namespace):
+                new_prefix = '%s%s.' % (prefix, key)
+                self.get_option_names(val, names, new_prefix)
+            elif isinstance(val, Option):
+                names.append("%s%s" % (prefix, key))
+            # skip aggregations, we want only Options
+        return names
+
+    #--------------------------------------------------------------------------
+    def _generate_config(self):
+        """This routine generates a copy of the DotDict based config"""
+        config = DotDict()
+        self._walk_config_copy_values(self.option_definitions, config)
+        return config
+
+    #--------------------------------------------------------------------------
+    def _walk_expanding_class_options(self, source_namespace=None,
+                                     parent_namespace=None):
+        if source_namespace is None:
+            source_namespace = self.option_definitions
+        expanded_keys = []
+        expansions_were_done = True
+        while expansions_were_done:
+            expansions_were_done = False
+            # can't use iteritems in loop, we're changing the dict
+            for key, val in source_namespace.items():
+                if isinstance(val, Namespace):
+                    self._walk_expanding_class_options(source_namespace=val,
+                                            parent_namespace=source_namespace)
+                elif (key not in expanded_keys and
+                        (inspect.isclass(val.value) or
+                         inspect.ismodule(val.value))):
+                    expanded_keys.append(key)
+                    expansions_were_done = True
+                    if key == 'application':
+                        target_namespace = parent_namespace
+                    else:
+                        target_namespace = source_namespace
+                    try:
+                        for o_key, o_val in \
+                                val.value.get_required_config().iteritems():
+                            target_namespace.__setattr__(o_key, o_val)
+                    except AttributeError:
+                        pass  # there are no required_options for this class
+                else:
+                    pass  # don't need to touch other types of Options
+            self._overlay_value_sources(ignore_mismatches=True)
+
+    #--------------------------------------------------------------------------
+    def _setup_auto_help(self):
+        help_option = Option(name='help', doc='print this', default=False)
+        self.definition_source_list.append({'help': help_option})
+
+    #--------------------------------------------------------------------------
+    def _get_config_pathname(self):
+        if os.path.isdir(self.config_pathname):
+            # we've got a path with no file name at the end
+            # use the appname as the file name and default to an 'ini'
+            # config file type
+            if self.app_name:
+                return os.path.join(self.config_pathname,
+                                    '%s.ini' % self.app_name)
+            else:
+                # there is no app_name yet
+                # we'll punt and use 'config'
+                return os.path.join(self.config_pathname, 'config.ini')
+        return self.config_pathname
+
+    #--------------------------------------------------------------------------
+    def _setup_admin_options(self, values_source_list):
+        base_namespace = Namespace()
+        base_namespace.admin = admin = Namespace()
+        admin.add_option(name='print_conf',
+                         default=None,
+                         doc='write current config to stdout '
+                             '(conf, ini, json)',
+                         )
+        admin.add_option(name='dump_conf',
+                         default='',
+                         doc='a pathname to which to write the current config',
+                         )
+        # only offer the config file admin options if they've been requested in
+        # the values source list
+        if ConfigFileFutureProxy in values_source_list:
+            default_config_pathname = self._get_config_pathname()
+            admin.add_option(name='conf',
+                             default=default_config_pathname,
+                             doc='the pathname of the config file '
+                                 '(path/filename)',
+                             )
+        return base_namespace
+
+    #--------------------------------------------------------------------------
+    def _overlay_value_sources(self, ignore_mismatches=True):
+        for a_settings_source in self.values_source_list:
+            try:
+                this_source_ignore_mismatches = (ignore_mismatches or
+                                    a_settings_source.always_ignore_mismatches)
+            except AttributeError:
+                # the settings source doesn't have the concept of always
+                # ignoring mismatches, so the original value of
+                # ignore_mismatches stands
+                this_source_ignore_mismatches = ignore_mismatches
+            options = a_settings_source.get_values(self,
+                            ignore_mismatches=this_source_ignore_mismatches)
+            self._overlay_value_sources_recurse(options,
+                            ignore_mismatches=this_source_ignore_mismatches)
+
+    #--------------------------------------------------------------------------
+    def _overlay_value_sources_recurse(self, source, destination=None,
+                                       prefix='', ignore_mismatches=True):
+        if destination is None:
+            destination = self.option_definitions
+        for key, val in source.items():
+            try:
+                sub_destination = destination
+                for subkey in key.split('.'):
+                    sub_destination = sub_destination[subkey]
+            except KeyError:
+                if ignore_mismatches:
+                    continue
+                if key == subkey:
+                    raise exc.NotAnOptionError('%s is not an option' % key)
+                raise exc.NotAnOptionError('%s subpart %s is not an option' %
+                                       (key, subkey))
+            except TypeError:
+                pass
+            if isinstance(sub_destination, Namespace):
+                self._overlay_value_sources_recurse(val, sub_destination,
+                                            prefix=('%s.%s' % (prefix, key)))
+            elif isinstance(sub_destination, Option):
+                sub_destination.set_value(val)
+            elif isinstance(sub_destination, Aggregation):
+                # there is nothing to do for Aggregations at this time
+                # it appears here anyway as a marker for future enhancements
+                pass
+
+    #--------------------------------------------------------------------------
+    def _walk_config_copy_values(self, source, destination):
+        for key, val in source.items():
+            value_type = type(val)
+            if isinstance(val, Option) or isinstance(val, Aggregation):
+                destination[key] = val.value
+            elif value_type == Namespace:
+                destination[key] = d = DotDict()
+                self._walk_config_copy_values(val, d)
+
+    #--------------------------------------------------------------------------
+    def _aggregate(self, source=None, local_namespace=None):
+        if source is None:
+            source = self.option_definitions
+            local_namespace = self.config
+        for key, val in source.items():
+            if isinstance(val, Namespace):
+                self._aggregate(val, local_namespace[key])
+            elif isinstance(val, Aggregation):
+                val.aggregate(self.config, local_namespace, self.args)
+                self._config = None
+            # skip Options, we're only dealing with Aggregations
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _option_sort(x_tuple):
+        key, val = x_tuple
+        if isinstance(val, Namespace):
+            return 'zzzzzzzzzzz%s' % key
+        else:
+            return key
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _block_password(qkey, key, value, block_password=True):
+        if block_password and 'password' in key.lower():
+            value = '*********'
+        return qkey, key, value
+
+    #--------------------------------------------------------------------------
+    def _walk_config(self, source=None, prefix='', blocked_keys=[],
+                    block_password=False):
+        if source == None:
+            source = self.option_definitions
+        options_list = source.items()
+        options_list.sort(key=ConfigurationManager._option_sort)
+        for key, val in options_list:
+            qualified_key = '%s%s' % (prefix, key)
+            if qualified_key in blocked_keys:
+                continue
+            if isinstance(val, Option):
+                yield self._block_password(qualified_key, key, val,
+                                          block_password)
+            if isinstance(val, Aggregation):
+                yield qualified_key, key, val
+            elif isinstance(val, Namespace):
+                if qualified_key == 'admin':
+                    continue
+                yield qualified_key, key, val
+                new_prefix = '%s%s.' % (prefix, key)
+                for xqkey, xkey, xval in self._walk_config(val,
+                                                          new_prefix,
+                                                          blocked_keys,
+                                                          block_password):
+                    yield xqkey, xkey, xval
+
+    #--------------------------------------------------------------------------
+    def _get_option(self, name):
+        source = self.option_definitions
+        try:
+            for sub_name in name.split('.'):
+                candidate = source[sub_name]
+                if isinstance(candidate, Option):
+                    return candidate
+                else:
+                    source = candidate
+        except KeyError:
+            pass  # we need to raise the exception below in either case
+                  # of a key error or execution falling through the loop
+        raise exc.NotAnOptionError('%s is not a known option name' % name)
+
+    #--------------------------------------------------------------------------
+    def _get_options(self, source=None, options=None, prefix=''):
+        if not source:
+            source = self.option_definitions
+        if options is None:
+            options = []
+        for key, val in source.items():
+            if isinstance(val, Namespace):
+                new_prefix = '%s%s.' % (prefix, key)
+                self._get_options(val, options, new_prefix)
+            else:
+                options.append(("%s%s" % (prefix, key), val))
+        return options

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -143,7 +143,7 @@ class TestCase(unittest.TestCase):
             ]
         e.sort()
         r = [(q, k, v.name if isinstance(v, config_manager.Option) else v._doc)
-              for q, k, v in c.walk_config()]
+              for q, k, v in c._walk_config()]
         r.sort()
         for expected, received in zip(e, r):
             self.assertEqual(received, expected)
@@ -184,8 +184,8 @@ class TestCase(unittest.TestCase):
                                     use_auto_help=False,
                                     argv_source=[])
         o = {"a": 2, "c.z": 22, "c.x": 'noob', "c.y": "2.89"}
-        c.overlay_config_recurse(o)
-        d = c.generate_config()
+        c._overlay_value_sources_recurse(o)
+        d = c._generate_config()
         e = DotDict()
         e.a = 2
         e.b = 17
@@ -213,8 +213,8 @@ class TestCase(unittest.TestCase):
                                     use_auto_help=False,
                                     argv_source=[])
         o = {"a": 2, "c.z": 22, "c.x": 'noob', "c.y": "2.89", "n": "not here"}
-        c.overlay_config_recurse(o, ignore_mismatches=True)
-        d = c.generate_config()
+        c._overlay_value_sources_recurse(o, ignore_mismatches=True)
+        d = c._generate_config()
         e = DotDict()
         e.a = 2
         e.b = 17
@@ -249,7 +249,7 @@ class TestCase(unittest.TestCase):
           "c.n": "not here"
         }
         self.assertRaises(NotAnOptionError,
-                          c.overlay_config_recurse, output,
+                          c._overlay_value_sources_recurse, output,
                           ignore_mismatches=False)
 
     def test_overlay_config_4(self):
@@ -595,7 +595,7 @@ string =   from ini
         e.sort()
         self.assertEqual(names, e)
 
-    def test_get_option_by_name(self):
+    def test_get_option(self):
         n = config_manager.Namespace()
         n.add_option('a', 1, 'the a')
         n.b = 17
@@ -612,14 +612,14 @@ string =   from ini
                                     #use_config_files=False,
                                     use_auto_help=False,
                                     argv_source=[])
-        self.assertEqual(c.get_option_by_name('a'), n.a)
-        self.assertEqual(c.get_option_by_name('b').name, 'b')
-        self.assertEqual(c.get_option_by_name('c.fred'), n.c.fred)
-        self.assertEqual(c.get_option_by_name('c.wilma'), n.c.wilma)
-        self.assertEqual(c.get_option_by_name('d.fred'), n.d.fred)
-        self.assertEqual(c.get_option_by_name('d.wilma'), n.d.wilma)
-        self.assertEqual(c.get_option_by_name('d.wilma'), n.d.wilma)
-        self.assertEqual(c.get_option_by_name('d.x.size'), n.d.x.size)
+        self.assertEqual(c._get_option('a'), n.a)
+        self.assertEqual(c._get_option('b').name, 'b')
+        self.assertEqual(c._get_option('c.fred'), n.c.fred)
+        self.assertEqual(c._get_option('c.wilma'), n.c.wilma)
+        self.assertEqual(c._get_option('d.fred'), n.d.fred)
+        self.assertEqual(c._get_option('d.wilma'), n.d.wilma)
+        self.assertEqual(c._get_option('d.wilma'), n.d.wilma)
+        self.assertEqual(c._get_option('d.x.size'), n.d.x.size)
 
     def test_output_summary(self):
         """test_output_summary: the output from help"""
@@ -866,7 +866,7 @@ string =   from ini
                                     use_admin_controls=True,
                                     use_auto_help=False,
                                     argv_source=[])
-        r = c.get_options()
+        r = c._get_options()
         e = (
              ('admin.print_conf', 'print_conf', None),
              ('admin.application', 'application', MyApp),
@@ -1093,7 +1093,7 @@ string =   from ini
                 temp_fn = os.path.isdir
                 os.path.isdir = lambda x: False
                 try:
-                    r = super(MyConfigManager, self).get_config_pathname()
+                    r = super(MyConfigManager, self)._get_config_pathname()
                 finally:
                     os.path.isdir = temp_fn
                 return r
@@ -1109,7 +1109,7 @@ string =   from ini
                           config_pathname='fred')
 
     def test_ConfigurationManager_block_password(self):
-        function = config_manager.ConfigurationManager.block_password
+        function = config_manager.ConfigurationManager._block_password
         self.assertEqual(function('foo', 'bar', 'peter', block_password=False),
                          ('foo', 'bar', 'peter'))
         self.assertEqual(function('foo', 'bar', 'peter', block_password=True),

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -176,7 +176,7 @@ class TestCase(unittest.TestCase):
           ('source.c', 'c', functools.partial(option_test, expected=e.s.c)),
         ]
 
-        c_contents = [(qkey, key, val) for qkey, key, val in c.walk_config()]
+        c_contents = [(qkey, key, val) for qkey, key, val in c._walk_config()]
         c_contents.sort()
         e.sort()
         for c_tuple, e_tuple in zip(c_contents, e):

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -119,7 +119,7 @@ def wrap(value_source_list, a_config_manager):
     wrapped_sources = []
     for a_source in value_source_list:
         if a_source is ConfigFileFutureProxy:
-            a_source = a_config_manager.get_option_by_name('admin.conf').value
+            a_source = a_config_manager._get_option('admin.conf').value
         handlers = type_handler_dispatch.get_handlers(a_source)
         wrapped_source = None
         error_history = []

--- a/configman/value_sources/for_configparse.py
+++ b/configman/value_sources/for_configparse.py
@@ -68,7 +68,7 @@ class ValueSource(object):
         self.top_level_section_name = top_level_section_name
         if source is ConfigParser:
             try:
-                app = config_manager.get_option_by_name('admin.application')
+                app = config_manager._get_option('admin.application')
                 source = "%s.%s" % (app.value.app_name, file_name_extension)
             except AttributeError:
                 # we likely don't have the admin.application object set up yet.
@@ -110,7 +110,7 @@ class ValueSource(object):
         dummies."""
         if self.delayed_parser_instantiation:
             try:
-                app = config_manager.get_option_by_name('admin.application')
+                app = config_manager._get_option('admin.application')
                 source = "%s%s" % (app.value.app_name, file_name_extension)
                 self.configparser = self._create_parser(source)
                 self.delayed_parser_instantiation = False
@@ -143,7 +143,7 @@ class ValueSource(object):
                    conv.py_obj_to_str(val.from_string_converter)
                 val_str = conv.option_value_str(val)
                 print >> output_stream, '%s=%s\n' % (key, val_str)
-            elif isinstance(val, opt.Aggregation):
+            elif isinstance(val, option.Aggregation):
                 # there is nothing to do for Aggregations at this time
                 # it appears here anyway as a marker for future enhancements
                 pass

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -117,7 +117,7 @@ class ValueSource(object):
                 if not name:
                     raise NotAnOptionError('%s is not a valid short'
                                               ' form option' % opt_name[1:])
-            option_ = config_manager.get_option_by_name(name)
+            option_ = config_manager._get_option(name)
             if option_.from_string_converter == conv.boolean_converter:
                 command_line_values[name] = not option_.default
             else:

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -64,7 +64,7 @@ class ValueSource(object):
         self.values = None
         if source is json:
             try:
-                app = the_config_manager.get_option_by_name(
+                app = the_config_manager._get_option(
                                                       'admin.application')
                 source = "%s.%s" % (app.value.app_name, file_name_extension)
             except (AttributeError, KeyError):


### PR DESCRIPTION
refactored config_manager so that methods are divided into public and private.  Some methods got renames in the process.

Also rearranged code such that all public methods appear first in the source code to aid readablity.

Also documented the API for all public methods
