### PR TITLE
parentage2: added a search algorithm to the DotDict class

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -461,7 +461,6 @@ class ConfigurationManager(object):
             expansions_were_done = False
             # can't use iteritems in loop, we're changing the dict
             for key, val in source_namespace.items():
-                print "###%s###%s" % (key, val)
                 if isinstance(val, Namespace):
                     self._walk_expanding_class_options(source_namespace=val,
                                             parent_namespace=source_namespace)
@@ -477,7 +476,6 @@ class ConfigurationManager(object):
                     try:
                         for o_key, o_val in \
                                 val.value.get_required_config().iteritems():
-                            print "***%s***%s" % (o_key, o_val)
                             target_namespace.__setattr__(o_key,
                                                          copy.deepcopy(o_val))
                     except AttributeError:

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -461,6 +461,7 @@ class ConfigurationManager(object):
             expansions_were_done = False
             # can't use iteritems in loop, we're changing the dict
             for key, val in source_namespace.items():
+                print "###%s###%s" % (key, val)
                 if isinstance(val, Namespace):
                     self._walk_expanding_class_options(source_namespace=val,
                                             parent_namespace=source_namespace)
@@ -476,6 +477,7 @@ class ConfigurationManager(object):
                     try:
                         for o_key, o_val in \
                                 val.value.get_required_config().iteritems():
+                            print "***%s***%s" % (o_key, o_val)
                             target_namespace.__setattr__(o_key,
                                                          copy.deepcopy(o_val))
                     except AttributeError:

--- a/configman/dotdict.py
+++ b/configman/dotdict.py
@@ -100,7 +100,7 @@ class DotDict(collections.MutableMapping):
     def __getitem__(self, key):
         """define the square bracket operator to refer to the object's __dict__
         for fetching values."""
-        return self.__dict__[key]
+        return getattr(self, key)
 
     def __setitem__(self, key, value):
         """define the square bracket operator to refer to the object's __dict__

--- a/configman/dotdict.py
+++ b/configman/dotdict.py
@@ -37,7 +37,119 @@
 # ***** END LICENSE BLOCK *****
 
 
-class DotDict(dict):
-    __getattr__ = dict.__getitem__
-    __setattr__ = dict.__setitem__
-    __delattr__ = dict.__delitem__
+import collections
+import weakref
+
+
+class DotDict(collections.MutableMapping):
+    """This class is a mapping that stores its items within the __dict__
+    of a regular class.  This means that items can be access with either
+    the regular square bracket notation or dot notation of class instance
+    attributes:
+
+        d = DotDict()
+        d['a'] = 23
+        assert d['a'] == 23
+        assert d.a == 23
+        d.b = 17
+        assert d['b'] == 17
+        assert d.b == 17
+
+    Because it is a Mapping and key lookup for mappings requires the raising of
+    a KeyError when a Key is missing, KeyError is used when an AttributeError
+    might normally be expected:
+
+        d = DotDict()
+        try:
+            d.a
+        except KeyError:
+            print 'yep, we got a KeyError'
+        except AttributeError:
+            print 'nope, this will never happen'
+
+    In addition, this mapping has special semantics when nested with mappings
+    of the same type.
+
+        d = DotDict()
+        d.a = 23
+        d.dd = DotDict()
+        assert d.dd.a == 23
+
+    Nested instances of DotDict, when faced with a key not within the mapping,
+    will defer to the parent DotDict to find a key.  Only if the key is not
+    found in the root of the nested mappings will the KeyError be raised.  This
+    is similar to the "acquisition" system found in Zope.
+
+        d = DotDict()
+        d.dd = DotDict()
+        try:
+            d.dd.x
+        except KeyError:
+            print "'x' was not found in d.dd or in d"
+    """
+
+    def __init__(self, initializer=None):
+        """the constructor allows for initialization from another mapping.
+
+        parameters:
+            initializer - a mapping of keys and values to be added to this
+                          mapping."""
+        if isinstance(initializer, collections.Mapping):
+            self.__dict__.update(initializer)
+        elif initializer is not None:
+            raise TypeError('can only initialize with a Mapping')
+
+    def __setattr__(self, key, value):
+        """this function saves keys into the mapping's __dict__.  If the
+        item being added is another instance of DotDict, it makes a weakref
+        proxy object of itself and assigns it to '_parent' in the incoming
+        DotDict."""
+        if isinstance(value, DotDict) and key != '_parent':
+            value._parent = weakref.proxy(self)
+        self.__dict__[key] = value
+
+    def __getattr__(self, key):
+        """if a key is not found in the __dict__ using the regular python
+        attribute reference algorithm, this function will try to get it from
+        parent class."""
+        if key == '_parent':
+            raise AttributeError('_parent')
+        try:
+            return getattr(self._parent, key)
+        except AttributeError:  # no parent attribute
+            # the copy.deepcopy function will try to probe this class for an
+            # instance of __deepcopy__.  If an AttributeError is raised, then
+            # copy.deepcopy goes on with out it.  However, this class raises
+            # a KeyError instead and copy.deepcopy can't handle it.  So we
+            # make sure that any missing attribute that begins with '__'
+            # raises an AttributeError instead of KeyError.
+            if key.startswith('__'):
+                raise
+            raise KeyError(key)
+
+    def __getitem__(self, key):
+        """define the square bracket operator to refer to the object's __dict__
+        for fetching values."""
+        return self.__dict__[key]
+
+    def __setitem__(self, key, value):
+        """define the square bracket operator to refer to the object's __dict__
+        for setting values."""
+        self.__dict__[key] = value
+
+    def __delitem__(self, key):
+        """define the square bracket operator to refer to the object's __dict__
+        for deleting values."""
+        del self.__dict__[key]
+
+    def __iter__(self):
+        """redirect the default iterator to iterate over the object's __dict__
+        making sure that it ignores the special '_' keys.  We want those items
+        ignored or we risk infinite recursion, not with this function, but
+        with the clients of this class deep within configman"""
+        return (k for k in self.__dict__
+                     if not k.startswith('_'))
+
+    def __len__(self):
+        """makes the len function also ignore the '_' keys"""
+        return len([x for x in self.__iter__()])

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -54,24 +54,20 @@ class Namespace(dotdict.DotDict):
         else:
             o = Option(name=name, default=value, value=value)
         super(Namespace, self).__setattr__(name, o)
-        #self.__setitem__(name, o)
 
     #--------------------------------------------------------------------------
     def add_option(self, name, *args, **kwargs):
         an_option = Option(name, *args, **kwargs)
         setattr(self, name, an_option)
-        #self[name] = an_option
 
     #--------------------------------------------------------------------------
     def add_aggregation(self, name, function):
         an_aggregation = Aggregation(name, function)
         setattr(self, name, an_aggregation)
-        #self[name] = an_aggregation
 
     #--------------------------------------------------------------------------
     def namespace(self, name, doc=''):
         setattr(self, name, Namespace(doc=doc))
-        #self[name] = Namespace(doc=doc)
 
     #--------------------------------------------------------------------------
     def set_value(self, name, value, strict=True):
@@ -80,13 +76,11 @@ class Namespace(dotdict.DotDict):
         prefix = name_parts[0]
         try:
             candidate = getattr(self, prefix)
-            #candidate = self[prefix]
         except KeyError:
             if strict:
                 raise
             candidate = Option(name)
             setattr(self, prefix, candidate)
-            #self[prefix] = candidate = Option(name)
         candidate_type = type(candidate)
         if candidate_type == Namespace:
             candidate.set_value(name_parts[1], value, strict)

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -37,7 +37,7 @@
 # ***** END LICENSE BLOCK *****
 
 import unittest
-from configman.dotdict import DotDict
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 
 class TestCase(unittest.TestCase):
@@ -79,11 +79,11 @@ class TestCase(unittest.TestCase):
         self.assertEqual(dd.get('age', 0), 0)
 
     def test_nesting(self):
-        d = DotDict()
+        d = DotDictWithAcquisition()
         d.e = 1
-        d.dd = DotDict()
+        d.dd = DotDictWithAcquisition()
         d.dd.f = 2
-        d.dd.ddd = DotDict()
+        d.dd.ddd = DotDictWithAcquisition()
         d.dd.ddd.g = 3
         d['a'] = 21
         d.dd['a'] = 22
@@ -112,7 +112,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(d.keys(), ['a', 'dd', 'e'])
         self.assertEqual(list(d.iterkeys()), ['a', 'dd', 'e'])
 
-        d.xxx = DotDict()
+        d.xxx = DotDictWithAcquisition()
         d.xxx.p = 69
         del d.xxx.p
         try:
@@ -122,13 +122,13 @@ class TestCase(unittest.TestCase):
             pass
 
         # initialization
-        d.yy = DotDict(dict(foo='bar'))
+        d.yy = DotDictWithAcquisition(dict(foo='bar'))
         self.assertEqual(d.yy.foo, 'bar')
 
         # clashing names
-        d.zzz = DotDict()
+        d.zzz = DotDictWithAcquisition()
         d.zzz.Bool = 'True'
-        d.zzz.www = DotDict()
+        d.zzz.www = DotDictWithAcquisition()
         self.assertEqual(d.zzz.www.Bool, 'True')
         d.zzz.www.Bool = 'False'
         self.assertEqual(d.zzz.www.Bool, 'False')

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -133,4 +133,17 @@ class TestCase(unittest.TestCase):
         d.zzz.www.Bool = 'False'
         self.assertEqual(d.zzz.www.Bool, 'False')
 
+        # test __setitem__ and __getitem__
+        d = DotDictWithAcquisition()
+        d.a = 17
+        d['dd'] = DotDictWithAcquisition()
+        self.assertEqual(d.dd.a, 17)
+        d['dd']['ddd'] = DotDictWithAcquisition()
+        self.assertEqual(d.dd.ddd.a, 17)
+        self.assertEqual(d['dd']['ddd'].a, 17)
+        self.assertEqual(d['dd']['ddd']['dd'].a, 17)
+
+
+
+
 

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -68,23 +68,69 @@ class TestCase(unittest.TestCase):
     def test_key_errors(self):
         dd = DotDict()
 
+        self.assertRaises(KeyError, dd.get('name'))
         try:
-            dd['name']
+            dd.name
             raise AssertionError("should have raised KeyError")
         except KeyError:
             pass
-
-        try:
-            dd.age
-            raise AssertionError("should have raised KeyError")
-        except KeyError:
-            pass
-
-        try:
-            getattr(dd, 'name')
-            raise AssertionError("should have raised KeyError")
-        except KeyError:
-            pass
-
+        #self.assertRaises(KeyError, getattr(dd, 'name'))
         self.assertEqual(dd.get('age'), None)
         self.assertEqual(dd.get('age', 0), 0)
+
+    def test_nesting(self):
+        d = DotDict()
+        d.e = 1
+        d.dd = DotDict()
+        d.dd.f = 2
+        d.dd.ddd = DotDict()
+        d.dd.ddd.g = 3
+        d['a'] = 21
+        d.dd['a'] = 22
+
+        self.assertEqual(d.dd.ddd.e, 1)
+        self.assertEqual(d.dd.e, 1)
+        self.assertEqual(d.e, 1)
+
+        self.assertEqual(d.dd.ddd.a, 22)
+        self.assertEqual(d.dd.a, 22)
+        self.assertEqual(d.a, 21)
+
+        self.assertEqual(d.dd.ddd.f, 2)
+        self.assertEqual(d.dd.f, 2)
+        try:
+            d.f
+            raise AssertionError("should have raised KeyError")
+        except KeyError:
+            pass
+        self.assertEqual(d.dd.dd.dd.dd.ddd.f, 2)
+        self.assertEqual(d.dd.ddd.dd.ddd.dd.ddd.e, 1)
+
+        self.assertEqual(len(d), 3)
+        _keys = [x for x in d]
+        self.assertEqual(_keys, ['a', 'dd', 'e'])
+        self.assertEqual(d.keys(), ['a', 'dd', 'e'])
+        self.assertEqual(list(d.iterkeys()), ['a', 'dd', 'e'])
+
+        d.xxx = DotDict()
+        d.xxx.p = 69
+        del d.xxx.p
+        try:
+            d.xxx.p
+            assert 0
+        except KeyError:
+            pass
+
+        # initialization
+        d.yy = DotDict(dict(foo='bar'))
+        self.assertEqual(d.yy.foo, 'bar')
+
+        # clashing names
+        d.zzz = DotDict()
+        d.zzz.Bool = 'True'
+        d.zzz.www = DotDict()
+        self.assertEqual(d.zzz.www.Bool, 'True')
+        d.zzz.www.Bool = 'False'
+        self.assertEqual(d.zzz.www.Bool, 'False')
+
+

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -229,24 +229,24 @@ class TestCase(unittest.TestCase):
         n4.add_option('name', 'Peter')
         self.assertEqual(n4, n3)
 
-    #def test_deep_copy(self):
-        #from copy import deepcopy
+    def test_deep_copy(self):
+        from copy import deepcopy
 
-        #n = config_manager.Namespace()
-        #n2 = deepcopy(n)
-        #self.assertTrue(n is not n2)
+        n = config_manager.Namespace()
+        n2 = deepcopy(n)
+        self.assertTrue(n is not n2)
 
-        #n = config_manager.Namespace()
-        #n.add_option('name', 'Peter')
-        #n3 = deepcopy(n)
-        #self.assertEqual(n, n3)
-        #self.assertTrue(n.name is not n3.name)
+        n = config_manager.Namespace()
+        n.add_option('name', 'Peter')
+        n3 = deepcopy(n)
+        self.assertEqual(n, n3)
+        self.assertTrue(n.name is not n3.name)
 
-        #def foo(all, local, args):
-            #return 17
-        #n = config_manager.Namespace()
-        #n.add_aggregation('a', foo)
-        #n4 = deepcopy(n)
-        #self.assertTrue(n.a is not n4.a)
+        def foo(all, local, args):
+            return 17
+        n = config_manager.Namespace()
+        n.add_aggregation('a', foo)
+        n4 = deepcopy(n)
+        self.assertTrue(n.a is not n4.a)
 
 

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -178,7 +178,6 @@ class TestCase(unittest.TestCase):
 
         c_contents = [(qkey, key, val) for qkey, key, val in c._walk_config()]
         c_contents.sort()
-        print c_contents
         e.sort()
         for c_tuple, e_tuple in zip(c_contents, e):
             qkey, key, val = c_tuple

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -178,6 +178,7 @@ class TestCase(unittest.TestCase):
 
         c_contents = [(qkey, key, val) for qkey, key, val in c._walk_config()]
         c_contents.sort()
+        print c_contents
         e.sort()
         for c_tuple, e_tuple in zip(c_contents, e):
             qkey, key, val = c_tuple
@@ -227,25 +228,25 @@ class TestCase(unittest.TestCase):
         n4 = config_manager.Namespace()
         n4.add_option('name', 'Peter')
         self.assertEqual(n4, n3)
-        
-    def test_deep_copy(self):
-        from copy import deepcopy
-        
-        n = config_manager.Namespace()
-        n2 = deepcopy(n)
-        self.assertTrue(n is not n2)
 
-        n = config_manager.Namespace()
-        n.add_option('name', 'Peter')
-        n3 = deepcopy(n)
-        self.assertEqual(n, n3)
-        self.assertTrue(n.name is not n3.name)
-        
-        def foo(all, local, args):
-            return 17
-        n = config_manager.Namespace()
-        n.add_aggregation('a', foo)
-        n4 = deepcopy(n)
-        self.assertTrue(n.a is not n4.a)
+    #def test_deep_copy(self):
+        #from copy import deepcopy
+
+        #n = config_manager.Namespace()
+        #n2 = deepcopy(n)
+        #self.assertTrue(n is not n2)
+
+        #n = config_manager.Namespace()
+        #n.add_option('name', 'Peter')
+        #n3 = deepcopy(n)
+        #self.assertEqual(n, n3)
+        #self.assertTrue(n.name is not n3.name)
+
+        #def foo(all, local, args):
+            #return 17
+        #n = config_manager.Namespace()
+        #n.add_aggregation('a', foo)
+        #n4 = deepcopy(n)
+        #self.assertTrue(n.a is not n4.a)
 
 


### PR DESCRIPTION
One of the interesting problems that I've encountered in working with configman is that classes instantiated from options need to have configuration information about themselves as well as global configuration.  For example, let's say we have this hierarchy

config
config.logger
config.source
config.source.class1
config.source.class1.kls
config.source.class1.param1
config.source.class1.param2

where 'config', 'source' and 'class1' are all namespaces.  'logger' is an object to do logging. 'kls' is a python class.  'param1' and 'param2' are requirements of the class in 'kls'.

if we try to instantiate 'kls', we're tempted to do so  like this:

```
config.source.class1.kls(config)
```

but that would be wrong.  'kls' will end up looking for its requirements 'param1' and 'param2' directly in 'config' rather than way down the hierarchy in 'config.source.class1'.  'kls' doesn't know where it is in the hierarchy.  The correct way to instantiate 'kls' is like this:

```
config.source.class1.kls(config.source.class1)
```

that aims 'kls' at the right level of the hierarchy to find its parameters.  Unfortunately, that cuts off 'kls' from the opportunity to use parameters (like 'logger') found all the way down in 'config'. 

The solution proposed here is to make the config DotDict object more intelligent.  Rather than just return a KeyError when a key is missing from a nested DotDict, a search happens automatically up through each parent until the missing key is found.  If the key is not found, even in the root DotDict, only then is the KeyError raised.
