### PR TITLE
enhanced class list corverter for different formats and extra data 

### DIFF
--- a/configman/converters.py
+++ b/configman/converters.py
@@ -48,7 +48,6 @@ from namespace import Namespace
 
 from .datetime_util import datetime_from_ISO_string as datetime_converter
 from .datetime_util import date_from_ISO_string as date_converter
-from .datetime_util import time_from_string as time_converter
 
 import datetime_util
 

--- a/configman/datetime_util.py
+++ b/configman/datetime_util.py
@@ -52,6 +52,16 @@ def datetime_from_ISO_string(s):
             return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f')
 
 
+def time_from_string(s):
+    """ Take an ISO date string of the form HH:MM:SS.S
+    and convert it into an instance of datetime.datetime
+    """
+    try:
+        return datetime.time.strftime(s, '%H:%M:%S')
+    except ValueError:
+        return datetime.time.strftime(s, '%H:%M:%S.%f')
+
+
 def date_from_ISO_string(s):
     """ Take an ISO date string of the form YYYY-MM-DD
     and convert it into an instance of datetime.date

--- a/configman/datetime_util.py
+++ b/configman/datetime_util.py
@@ -52,16 +52,6 @@ def datetime_from_ISO_string(s):
             return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f')
 
 
-def time_from_string(s):
-    """ Take an ISO date string of the form HH:MM:SS.S
-    and convert it into an instance of datetime.datetime
-    """
-    try:
-        return datetime.time.strftime(s, '%H:%M:%S')
-    except ValueError:
-        return datetime.time.strftime(s, '%H:%M:%S.%f')
-
-
 def date_from_ISO_string(s):
     """ Take an ISO date string of the form YYYY-MM-DD
     and convert it into an instance of datetime.date

--- a/configman/tests/test_converters.py
+++ b/configman/tests/test_converters.py
@@ -107,11 +107,41 @@ def get_extra(class_list_tuple):
     try:
         n.add_option('time',
                      doc='absolute execution time',
-                     default=class_list_tuple[2].strip(),
-                     from_string_converter=converters.time_converter)
+                     default=class_list_tuple[2].strip())
     except IndexError:
         pass
     return n
+
+def make_class_list_fn(class_namespace_prefix='cls', class_option_name='cls'):
+    def class_list_fn(global_config, local_config, args):
+        class_list = []
+        for a_class_namespace in local_config.keys():
+            if a_class_namespace.startswith(class_namespace_prefix):
+                class_list.append(
+                  local_config[a_class_namespace][class_option_name])
+        return class_list
+    return class_list_fn
+
+def make_class_list_extra_fn(class_namespace_prefix='cls',
+                             class_option_name='cls'):
+    def class_list_fn(global_config, local_config, args):
+        class_list = []
+        for a_class_namespace in local_config.keys():
+            if a_class_namespace.startswith(class_namespace_prefix):
+                try:
+                    class_extra_tuple = (
+                      local_config[a_class_namespace][class_option_name],
+                      local_config[a_class_namespace].frequency,
+                      local_config[a_class_namespace].time
+                    )
+                except KeyError:
+                    class_extra_tuple = (
+                      local_config[a_class_namespace][class_option_name],
+                      local_config[a_class_namespace].frequency,
+                    )
+                class_list.append(class_extra_tuple)
+        return class_list
+    return class_list_fn
 
 
 class TestCase(unittest.TestCase):
@@ -296,6 +326,13 @@ class TestCase(unittest.TestCase):
                             class_extractor=get_class,
                             extra_extractor=get_extra,
                             instantiate_classes=True))
+        # make an aggregation that is a list of class objects
+        rc.add_aggregation('class_list',
+                           make_class_list_fn())
+        # make an aggregation that is a list of class objects and the
+        # extra data as a tuple
+        rc.add_aggregation('class_list_with_extra',
+                           make_class_list_extra_fn())
 
         cm = ConfigurationManager(rc, values_source_list=[])
         config = cm.get_config()
@@ -323,5 +360,16 @@ class TestCase(unittest.TestCase):
         self.assertTrue('frequency' in config.cls2)
         self.assertTrue('time' in config.cls2)
 
+        self.assertEqual(len(config.class_list), 3)
+        classes = (config.cls0.cls,
+                   config.cls1.cls,
+                   config.cls2.cls)
+        for ec, rc in zip(classes, config.class_list):
+            self.assertTrue(ec is rc)
 
-
+        self.assertEqual(len(config.class_list_with_extra), 3)
+        classes = ((config.cls0.cls, 1, '02:00:00'),
+                   (config.cls1.cls, 2),
+                   (config.cls2.cls, 3, '03:00:00'))
+        for ec, rc in zip(classes, config.class_list_with_extra):
+            self.assertEqual(ec, rc)

--- a/configman/tests/test_converters.py
+++ b/configman/tests/test_converters.py
@@ -89,7 +89,7 @@ class Gamma(RequiredConfig):
         self.g = config.g
 
 def splitter(class_list_str):
-    return [tuple(line.split('|')) for line in class_list_str.split('\n')]
+    return [tuple(line.split('|')) for line in class_list_str.splitlines()]
 
 def get_class(class_list_element):
     try:


### PR DESCRIPTION
the class_list_converter had a hard coded comma delimited string format for the class list.  This enhancement replaces the hard coding with a function that allows arbitrary alternative formats.  There is also the ability to add extra data to go with each class.   

sample input:

```
"""configman.tests.test_converters.Alpha|1|02:00:00
configman.tests.test_converters.Beta|2
configman.tests.test_converters.Gamma|3|03:00:00"""
```

sample config output:

```
config
config.cls0
config.cls0.cls == configman.tests.test_converters.Alpha 
config.cls0.cls_instance == configman.tests.test_converters.Alpha()
config.cls0.cls.frequency == 1
config.cls0.cls.time == datetime.time(02:00:00)
config.cls1
config.cls1.cls == configman.tests.test_converters.Beta 
config.cls1.cls_instance == configman.tests.test_converters.Beta()
config.cls1.cls.frequency == 2
config.cls2
config.cls2.cls == configman.tests.test_converters.Gamma 
config.cls2.cls_instance == configman.tests.test_converters.Gamma()
config.cls2.cls.frequency == 3
config.cls2.cls.time == datetime.time(03:00:00)
```

See the demo in the test_converters.py in the `test_classes_in_namespaces_converter_5` test.
