### PR TITLE
fixes bug where zero length file is created

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -36,7 +36,7 @@
 #
 # ***** END LICENSE BLOCK *****
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'
 
 # Having these here makes it possible to easily import once configman is
 # installed.

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -375,10 +375,10 @@ class ConfigurationManager(object):
 
         option_iterator = functools.partial(self._walk_config,
                                        blocked_keys=blocked_keys)
-        with opener() as config_fp:
-            value_sources.write(config_file_type,
-                                option_iterator,
-                                config_fp)
+
+        value_sources.write(config_file_type,
+                            option_iterator,
+                            opener)
 
     #--------------------------------------------------------------------------
     def log_config(self, logger):

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -38,6 +38,7 @@
 
 import sys
 import os
+import os.path
 import unittest
 from contextlib import contextmanager
 import ConfigParser
@@ -49,8 +50,10 @@ import configman.config_manager as config_manager
 from configman.dotdict import DotDict, DotDictWithAcquisition
 import configman.datetime_util as dtu
 from configman.config_exceptions import NotAnOptionError
-from configman.value_sources.source_exceptions import \
-                                                  AllHandlersFailedException
+from configman.value_sources.source_exceptions import (
+  AllHandlersFailedException,
+  UnknownFileExtensionException
+)
 import configman.value_sources
 import configman.value_sources.for_configparse
 
@@ -1119,6 +1122,25 @@ c.string =   from ini
                          'argument 3'],
             config_pathname='fred'
         )
+
+    def test_dump_conf_bad_extension(self):
+        n = config_manager.Namespace()
+
+        self.assertRaises(
+          UnknownFileExtensionException,
+          config_manager.ConfigurationManager,
+          n,
+          [getopt],
+          use_admin_controls=True,
+          use_auto_help=False,
+          quit_after_admin=False,
+          argv_source=['--admin.dump_conf=/tmp/fred.xxx',
+                       'argument 1',
+                       'argument 2',
+                       'argument 3'],
+          config_pathname='fred'
+        )
+        self.assertFalse(os.path.exists('/tmp/fred.xxx'))
 
     def test_print_conf_some_options_excluded(self):
         n = config_manager.Namespace()

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -146,14 +146,18 @@ def wrap(value_source_list, a_config_manager):
         wrapped_sources.append(wrapped_source)
     return wrapped_sources
 
+def has_registration_for(config_file_type):
+    return config_file_type in file_extension_dispatch
+
 
 def write(config_file_type,
           option_iterator,
-          output_stream=sys.stdout):
+          opener):
     if isinstance(config_file_type, basestring):
         try:
-            file_extension_dispatch[config_file_type](option_iterator,
-                                                         output_stream)
+            writer_fn = file_extension_dispatch[config_file_type]
+            with opener() as output_stream:
+                writer_fn(option_iterator, output_stream)
         except KeyError:
             raise UnknownFileExtensionException("%s isn't a registered file"
                                                    " name extension" %
@@ -161,7 +165,8 @@ def write(config_file_type,
     else:
         # this is the case where we've not gotten a file extension, but a
         # for_handler module.  Use the module's ValueSource's write method
-        config_file_type.ValueSource.write(option_iterator, output_stream)
+        with opener() as output_stream:
+            config_file_type.ValueSource.write(option_iterator, output_stream)
 
 
 def get_admin_options_from_command_line(config_manager):


### PR DESCRIPTION
A zero length file is created when attempting a config file write with an unregistered suffix.  This patch stops the file from being created if a proper writer cannot be found for the extension.
