### PR TITLE
enhanced configobj have an include directive

### DIFF
--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -272,3 +272,67 @@ foo=bar  # other comment
                     os.remove(include_file_name)
                 if os.path.isfile(ini_file_name):
                     os.remove(ini_file_name)
+
+        def test_configobj_relative_includes(self):
+            include_file_name = ''
+            ini_file_name = ''
+            try:
+                db_creds_dir = tempfile.mkdtemp()
+                db_creds_basename = os.path.basename(db_creds_dir)
+                ini_repo_dir = tempfile.mkdtemp()
+                ini_repo_basename = os.path.basename(ini_repo_dir)
+                with tempfile.NamedTemporaryFile(
+                  'w',
+                  suffix='ini',
+                  dir=db_creds_dir,
+                  delete=False
+                ) as f:
+                    include_file_name = f.name
+                    include_file_basename = os.path.basename(f.name)
+                    contents = (
+                      'dbhostname=myserver\n'
+                      'dbname=some_database\n'
+                      'dbuser=dwight\n'
+                      'dbpassword=secrets\n'
+                    )
+                    f.write(contents)
+
+                with tempfile.NamedTemporaryFile(
+                  'w',
+                  suffix='ini',
+                  dir=ini_repo_dir,
+                  delete=False
+                ) as f:
+                    ini_file_name = f.name
+                    contents = (
+                      '+include ../%s/%s\n'
+                      '\n'
+                      '[destination]\n'
+                      '+include ../%s/%s\n'
+                      % (db_creds_basename, include_file_basename,
+                         db_creds_basename, include_file_basename)
+                    )
+                    f.write(contents)
+                o = for_configobj.ValueSource(ini_file_name)
+                expected_dict = {
+                  'dbhostname': 'myserver',
+                  'dbname': 'some_database',
+                  'dbuser': 'dwight',
+                  'dbpassword': 'secrets',
+                  'destination': {
+                    'dbhostname': 'myserver',
+                    'dbname': 'some_database',
+                    'dbuser': 'dwight',
+                    'dbpassword': 'secrets',
+                  }
+                }
+                self.assertEqual(o.get_values(1, True), expected_dict)
+            finally:
+                if os.path.isfile(include_file_name):
+                    os.remove(include_file_name)
+                if os.path.isfile(ini_file_name):
+                    os.remove(ini_file_name)
+                if os.path.isdir(db_creds_dir):
+                    os.rmdir(db_creds_dir)
+                if os.path.isdir(ini_repo_dir):
+                    os.rmdir(ini_repo_dir)

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -38,6 +38,7 @@
 
 import sys
 import collections
+import re
 
 import configobj
 
@@ -53,6 +54,75 @@ can_handle = (configobj,
               configobj.ConfigObj,
               basestring,
              )
+
+
+class ConfigObjWithIncludes(configobj.ConfigObj):
+    """This derived class is an extention to ConfigObj that adds nested
+    includes to ini files.  Here's an example:
+
+    db.ini:
+
+        dbhostname=myserver
+        dbname=some_database
+        dbuser=dwight
+        dbpassword=secrets
+
+    app.ini:
+        [source]
+        +include ./db.ini
+
+        [destination]
+        +include ./db.ini
+
+    when the 'app.ini' file is loaded, ConfigObj will respond as if the file
+    had been written like this:
+        [source]
+        dbhostname=myserver
+        dbname=some_database
+        dbuser=dwight
+        dbpassword=secrets
+
+        [destination]
+        dbhostname=myserver
+        dbname=some_database
+        dbuser=dwight
+        dbpassword=secrets
+    """
+    _include_re = re.compile(r'^\s*\+include\s+(.*?)\s*$')
+
+    def _expand_files(self, file_name):
+        """This recursive function accepts a file name, opens the file and then
+        spools the contents of the file into a list, examining each line as it
+        does so.  If it detects a line beginning with "+include", it assumes
+        the string immediately following is a file name.  Recursing, the file
+        new file is openned and its contents are spooled into the accumulating
+        list."""
+        expanded_file_contents = []
+        with open(file_name) as f:
+            for a_line in f:
+                match = ConfigObjWithIncludes._include_re.match(a_line)
+                if match:
+                    include_file = match.group(1)
+                    new_lines = self._expand_files(include_file)
+                    expanded_file_contents.extend(new_lines)
+                else:
+                    expanded_file_contents.append(a_line.rstrip())
+        return expanded_file_contents
+
+    def _load(self, infile, configspec):
+        """this overrides the original ConfigObj method of the same name.  It
+        runs through the input file collecting lines into a list.  When
+        completed, this method submits the list of lines to the super class'
+        function of the same name.  ConfigObj proceeds, completely unaware
+        that it's input file has been preprocessed."""
+        if isinstance(infile, basestring):
+            expanded_file_contents = self._expand_files(infile)
+            super(ConfigObjWithIncludes, self)._load(
+              expanded_file_contents,
+              configspec
+            )
+        else:
+            super(ConfigObjWithIncludes, self)._load(infile, configspec)
 
 
 class LoadingIniFileFailsException(ValueException):
@@ -83,7 +153,8 @@ class ValueSource(object):
         if (isinstance(source, basestring) and
             source.endswith(file_name_extension)):
             try:
-                self.config_obj = configobj.ConfigObj(source)
+                #self.config_obj = configobj.ConfigObj(source)
+                self.config_obj = ConfigObjWithIncludes(source)
             except Exception, x:
                 raise LoadingIniFileFailsException(
                   "ConfigObj cannot load ini: %s" % str(x))


### PR DESCRIPTION
I derived a new class from ConfigObj and added a C style include directive.  It works like this:

```
db.ini:

    dbhostname=myserver
    dbname=some_database
    dbuser=dwight
    dbpassword=secrets

app.ini:
    [source]
    +include ./db.ini

    [destination]
    +include ./db.ini

when the 'app.ini' file is loaded, ConfigObj will respond as if the file
had been written like this:
    [source]
    dbhostname=myserver
    dbname=some_database
    dbuser=dwight
    dbpassword=secrets

    [destination]
    dbhostname=myserver
    dbname=some_database
    dbuser=dwight
    dbpassword=secrets
```
