### PR TITLE
added override default for Options

### DIFF
--- a/configman/option.py
+++ b/configman/option.py
@@ -39,7 +39,7 @@
 import collections
 
 import converters as conv
-from config_exceptions import CannotConvertError
+from config_exceptions import CannotConvertError, OptionError
 
 
 #==============================================================================
@@ -116,6 +116,39 @@ class Option(object):
         else:
             self.value = val
 
+    #--------------------------------------------------------------------------
+    def set_default(self, val, force=False):
+        """this function allows a default to be set on an option that dosen't
+        have one.  It is used when a base class defines an Option for use in
+        derived classes but cannot predict what value would useful to the
+        derived classes.  This gives the derived classes the opportunity to
+        set a logical default appropriate for the derived class' context.
+
+        For example:
+
+            class A(RequiredConfig):
+                required_config = Namespace()
+                required_config.add_option(
+                  'x',
+                  default=None
+                )
+
+            class B(A):
+                A.required_config.x.set_default(68)
+
+        parameters:
+            val - the value for the default
+            force - normally this function only works on Options that have not
+                    had a default set (default is None).  This boolean allows
+                    you to override an existing default.
+        """
+        if self.default is None or force:
+            self.default = val
+            self.set_value(val)
+        else:
+            raise OptionError("cannot override existing default without "
+                              "using the 'force' option")
+
 
 #==============================================================================
 class Aggregation(object):
@@ -133,5 +166,5 @@ class Aggregation(object):
     #--------------------------------------------------------------------------
     def aggregate(self, all_options, local_namespace, args):
         self.value = self.function(all_options, local_namespace, args)
-        
+
 

--- a/configman/required_config.py
+++ b/configman/required_config.py
@@ -7,7 +7,7 @@ class RequiredConfig(object):
     @classmethod
     def get_required_config(cls):
         result = Namespace()
-        for a_class in cls.__mro__:
+        for a_class in reversed(cls.__mro__):
             try:
                 result.update(a_class.required_config)
             except AttributeError:

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -43,7 +43,7 @@ import datetime
 import configman.converters as conv
 import configman.datetime_util as dtu
 from configman.option import Option
-from configman.config_exceptions import CannotConvertError
+from configman.config_exceptions import CannotConvertError, OptionError
 
 
 class TestCase(unittest.TestCase):
@@ -352,3 +352,23 @@ class TestCase(unittest.TestCase):
         val = {'justanother': 'dict!'}
         o1.set_value(val)
         self.assertEqual(o1.value, val)
+
+    def test_set_default(self):
+        o1 = Option(
+          'name',
+          default=23
+        )
+        self.assertEqual(o1.value, 23)
+        self.assertRaises(OptionError, o1.set_default, 68)
+        o1.set_default(78, force=True)
+        self.assertTrue(o1.value, 68)
+        self.assertTrue(o1.default, 68)
+
+        o2 = Option(
+          'name',
+          default=None
+        )
+        self.assertTrue(o2.value is None)
+        o2.set_default(68)
+        self.assertTrue(o2.value, 68)
+        self.assertTrue(o2.default, 68)


### PR DESCRIPTION
frequently in creating class hierarchies, the 'required_config' for a base class cannot know what defaults the derived classes will need.  Until now, there has been no facility for derived classes to reach down into the requirements of the base class and manipulate the requirements.  This change implements a simple interface for that need:

```
        class A(RequiredConfig):
            required_config = Namespace()
            required_config.add_option(
              'x',
              default=23
            )

        class B(A):
            A.required_config.x.override_default(68)
```
