### PR TITLE
added missing dict type to converters

### DIFF
--- a/configman/converters.py
+++ b/configman/converters.py
@@ -42,6 +42,7 @@ import datetime
 import types
 import inspect
 import collections
+import json
 
 from required_config import RequiredConfig
 from namespace import Namespace
@@ -316,6 +317,7 @@ from_string_converters = {
     str: str,
     unicode: unicode,
     bool: boolean_converter,
+    dict: json.loads,
     datetime.datetime: datetime_converter,
     datetime.date: date_converter,
     datetime.timedelta: timedelta_converter,
@@ -344,7 +346,6 @@ def py_obj_to_str(a_thing):
 def list_to_str(a_list):
     return ', '.join(to_string_converters[type(x)](x) for x in a_list)
 
-
 #------------------------------------------------------------------------------
 to_string_converters = {
     int: str,
@@ -354,6 +355,7 @@ to_string_converters = {
     list: list_to_str,
     tuple: list_to_str,
     bool: lambda x: 'True' if x else 'False',
+    dict: json.dumps,
     datetime.datetime: datetime_util.datetime_to_ISO_string,
     datetime.date: datetime_util.date_to_ISO_string,
     datetime.timedelta: datetime_util.timedelta_to_str,

--- a/configman/tests/test_converters.py
+++ b/configman/tests/test_converters.py
@@ -190,6 +190,20 @@ class TestCase(unittest.TestCase):
         self.assertEqual(function((int, str, 123, "hello")),
                          'int, str, 123, hello')
 
+    def test_dict_conversions(self):
+        d = {
+          'a': 1,
+          'b': 'fred',
+          'c': 3.1415
+        }
+        converter_fn = converters.to_string_converters[type(d)]
+        s = converter_fn(d)
+
+        # round  trip
+        converter_fn = converters.from_string_converters[type(d)]
+        dd = converter_fn(s)
+        self.assertEqual(dd, d)
+
     def test_classes_in_namespaces_converter_1(self):
         converter_fn = converters.classes_in_namespaces_converter('HH%d')
         class_list_str = ('configman.tests.test_converters.Foo,'

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -156,12 +156,12 @@ def write(config_file_type,
     if isinstance(config_file_type, basestring):
         try:
             writer_fn = file_extension_dispatch[config_file_type]
-            with opener() as output_stream:
-                writer_fn(option_iterator, output_stream)
         except KeyError:
             raise UnknownFileExtensionException("%s isn't a registered file"
                                                    " name extension" %
                                                    config_file_type)
+        with opener() as output_stream:
+            writer_fn(option_iterator, output_stream)
     else:
         # this is the case where we've not gotten a file extension, but a
         # for_handler module.  Use the module's ValueSource's write method

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -201,7 +201,10 @@ class ValueSource(object):
                 d = d[x]
             if isinstance(val, Option):
                 v = val.value
-                v_str = conv.to_string_converters[type(v)](v)
+                try:
+                    v_str = conv.to_string_converters[type(v)](v)
+                except KeyError:
+                    v_str = repr(v)
                 d[key] = v_str
         config = configobj.ConfigObj(destination_dict)
         config.write(outfile=output_stream)


### PR DESCRIPTION
the dict type was missing from configman conversion functions.  This conversion only handles basic types as values and assumes that keys are text.  It uses the json module to serialize and deserialize the dict to and from string.

This also includes a reordering of some code within config file writing handlers.  Formerly, if an unknown type was found, a key error would be raise and, unfortuately, caught by the code that would report that no handler existed for the requested config file type.  The rearrangement stops the masking of the true error.
