### PR TITLE
write configobj ini file manually because the default is ugly

### DIFF
--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -149,16 +149,47 @@ foo=bar  # other comment
               use_auto_help=False,
               argv_source=[]
             )
-            expected = """aaa = 2011-05-04T15:10:00
-[x]
-    password = secret
-    size = 100
+            expected = \
+"""# name: aaa
+# doc: the a
+# converter: configman.datetime_util.datetime_from_ISO_string
+aaa=2011-05-04 15:10:00
+
 [c]
-    wilma = waspish
-    fred = stupid
+
+    # name: fred
+    # doc: husband from Flintstones
+    # converter: str
+    fred=stupid
+
+    # name: wilma
+    # doc: wife from Flintstones
+    # converter: str
+    wilma=waspish
+
 [d]
-    ethel = silly
-    fred = crabby
+
+    # name: ethel
+    # doc: female neighbor from I Love Lucy
+    # converter: str
+    ethel=silly
+
+    # name: fred
+    # doc: male neighbor from I Love Lucy
+    # converter: str
+    fred=crabby
+
+[x]
+
+    # name: password
+    # doc: the password
+    # converter: str
+    password=secret
+
+    # name: size
+    # doc: how big in tons
+    # converter: int
+    size=100
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))


### PR DESCRIPTION
configobj comes with a function to write its own ini files from a nested dictionary.  It does a poor job.  Of course, it doesn't know anything about the configman doc strings on options, so it doesn't write them.  

This change adds a configobj compatible ini file writer to the hander for configobj .
