### PR TITLE
fixed pyobjects not being converted to strings in ini files

### DIFF
--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -241,7 +241,7 @@ class ValueSource(object):
             print >>output_stream, "%s%s=%s\n" % (
               indent_spacer,
               an_option.name,
-              an_option.default
+              conv.option_value_str(an_option)
             )
         next_level = level + 1
         for key, namespace in namespaces:


### PR DESCRIPTION
when rewriting the ini file for configobj, I err'd in not converting py objects into strings before writing the output.  this one line changes fixes my badness...
