### PR TITLE
add .travis.yaml, enable CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ demo/demo1.ini
 demo/demo1.json
 demo/demo2.ini
 docs/_build/
+MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# http://travis-ci.org/#!/mozilla/configman
+language: python
+
+python:
+    - 2.6
+    - 2.7
+
+before_install:
+    - pip install nose --use-mirrors
+
+install:
+    - python setup.py install
+
+script:
+    - nosetests configman
+
+notifications:
+    irc:
+        channels: "irc.mozilla.org#breakpad"


### PR DESCRIPTION
the job already [exists](http://travis-ci.org/#!/mozilla/configman)

the file passes the travis linter:

```
(configman)[lonnen (travis-ci-setup) configman]$ travis-lint 
Hooray, /Users/lonnen/repos/configman/.travis.yml seems to be solid!
```

tested on my fork and it works: http://travis-ci.org/#!/Lonnen/configman/builds/2204602
