### PR TITLE
added named arguments

### DIFF
--- a/configman/converters.py
+++ b/configman/converters.py
@@ -48,6 +48,7 @@ from namespace import Namespace
 
 from .datetime_util import datetime_from_ISO_string as datetime_converter
 from .datetime_util import date_from_ISO_string as date_converter
+from .config_exceptions import CannotConvertError
 
 import datetime_util
 
@@ -180,19 +181,21 @@ def class_converter(input_str):
         return eval(input_str)
     parts = [x.strip() for x in input_str.split('.') if x.strip()]
     try:
-        # first try as a complete module
-        package = __import__(input_str)
-    except ImportError:
-        # it must be a class from a module
-        if len(parts) == 1:
-            # since it has only one part, it must be a class from __main__
-            parts = ('__main__', input_str)
-        package = __import__('.'.join(parts[:-1]), globals(), locals(), [])
-    obj = package
-    for name in parts[1:]:
-        obj = getattr(obj, name)
-    return obj
-
+        try:
+            # first try as a complete module
+            package = __import__(input_str)
+        except ImportError:
+            # it must be a class from a module
+            if len(parts) == 1:
+                # since it has only one part, it must be a class from __main__
+                parts = ('__main__', input_str)
+            package = __import__('.'.join(parts[:-1]), globals(), locals(), [])
+        obj = package
+        for name in parts[1:]:
+            obj = getattr(obj, name)
+        return obj
+    except AttributeError, x:
+        raise CannotConvertError("%s cannot be found" % input_str)
 
 #------------------------------------------------------------------------------
 def classes_in_namespaces_converter(template_for_namespace="cls%d",

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -91,16 +91,7 @@ class Namespace(dotdict.DotDict):
         new_namespace = Namespace()
         for key, opt in self.iteritems():
             if isinstance(opt, Option):
-                new_namespace.add_option(
-                    opt.name,
-                    default=opt.default,
-                    doc=opt.doc,
-                    from_string_converter=opt.from_string_converter,
-                    value=opt.value,
-                    short_form=opt.short_form,
-                    exclude_from_print_conf=opt.exclude_from_print_conf,
-                    exclude_from_dump_conf=opt.exclude_from_dump_conf
-                )
+                new_namespace[key] = opt.copy()
             elif isinstance(opt, Aggregation):
                 new_namespace.add_aggregation(
                     opt.name,

--- a/configman/option.py
+++ b/configman/option.py
@@ -54,6 +54,7 @@ class Option(object):
                  short_form=None,
                  exclude_from_print_conf=False,
                  exclude_from_dump_conf=False,
+                 is_argument=False,
                  comment_out=False,
                  not_for_definition=False,
                  ):
@@ -71,6 +72,7 @@ class Option(object):
         if value is None:
             value = default
         self.value = value
+        self.is_argument = is_argument
         self.exclude_from_print_conf = exclude_from_print_conf
         self.exclude_from_dump_conf = exclude_from_dump_conf
         self.comment_out = comment_out
@@ -165,7 +167,9 @@ class Option(object):
             short_form=self.short_form,
             exclude_from_print_conf=self.exclude_from_print_conf,
             exclude_from_dump_conf=self.exclude_from_dump_conf,
+            is_argument=self.is_argument,
             comment_out=self.comment_out,
+            not_for_definition=self.not_for_definition,
         )
         return o
 

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -584,9 +584,9 @@ c.string =   from ini
         s = StringIO()
         c.output_summary(output_stream=s)
         r = s.getvalue()
-        self.assertTrue('Options:\n' in r)
+        self.assertTrue('OPTIONS:\n' in r)
 
-        options = r.split('Options:\n')[1]
+        options = r.split('OPTIONS:\n')[1]
         s.close()
 
         padding = '\n' + ' ' * 4
@@ -624,22 +624,22 @@ c.string =   from ini
             return s.getvalue()
 
         output = get_output(c)
-        assert 'Options:' in output
+        assert 'OPTIONS:' in output
         self.assertTrue('Application:' not in output)
 
         c.app_name = 'foobar'
         output = get_output(c)
-        assert 'Options:' in output
+        assert 'OPTIONS:' in output
         self.assertTrue('Application: foobar' in output)
 
         c.app_version = '1.0'
         output = get_output(c)
-        assert 'Options:' in output
+        assert 'OPTIONS:' in output
         self.assertTrue('Application: foobar 1.0' in output)
 
         c.app_description = "This ain't your mama's app"
         output = get_output(c)
-        assert 'Options:' in output
+        assert 'OPTIONS:' in output
         self.assertTrue('Application: foobar 1.0\n' in output)
         self.assertTrue("This ain't your mama's app\n\n" in output)
 
@@ -724,7 +724,7 @@ c.string =   from ini
                 output_stream.close()
                 self.assertTrue('Application: fred 1.0' in r)
                 self.assertTrue('my app\n\n' in r)
-                self.assertTrue('Options:\n' in r)
+                self.assertTrue('OPTIONS:\n' in r)
                 self.assertTrue('  --help' in r and 'print this' in r)
                 self.assertTrue('print this (default: True)' not in r)
                 self.assertTrue('  --password' in r)
@@ -1321,7 +1321,7 @@ c.string =   from ini
         )
         conf = c.get_config()
         self.assertEqual(len(conf), 3)
-        self.assertEqual(conf.keys(), ['admin', 'source', 'destination'])
+        self.assertEqual(conf.keys(), ['source', 'destination', 'admin'])
         self.assertEqual(len(conf.source), 3)
         self.assertEqual(conf.source.c, 33)
         self.assertEqual(conf.source.cls, T3)

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -153,9 +153,9 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(len(d), 3)
         _keys = [x for x in d]
-        self.assertEqual(_keys, ['a', 'dd', 'e'])
-        self.assertEqual(d.keys(), ['a', 'dd', 'e'])
-        self.assertEqual(list(d.iterkeys()), ['a', 'dd', 'e'])
+        self.assertEqual(_keys, ['e', 'dd', 'a'])
+        self.assertEqual(d.keys(), ['e', 'dd', 'a'])
+        self.assertEqual(list(d.iterkeys()), ['e', 'dd', 'a'])
 
         d.xxx = DotDictWithAcquisition()
         d.xxx.p = 69

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -124,7 +124,6 @@ for a_handler in for_handlers:
 def wrap(value_source_list, a_config_manager):
     wrapped_sources = []
     for a_source in value_source_list:
-        print a_source
         if a_source is ConfigFileFutureProxy:
             a_source = a_config_manager._get_option('admin.conf').default
             # raise hell if the config file doesn't exist

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -121,6 +121,14 @@ class ValueSource(object):
                 command_line_values[name] = not option_.default
             else:
                 command_line_values[name] = opt_val
+        for name, value in zip(
+            self._get_arguments(
+                config_manager.option_definitions,
+                command_line_values
+            ),
+            config_manager.args
+        ):
+            command_line_values[name] = value
         return command_line_values
 
     def getopt_create_opts(self, option_definitions):
@@ -217,3 +225,16 @@ class ValueSource(object):
                 except KeyError:
                     continue
         return None
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _get_arguments(option_definitions, switches_already_used):
+        for key in option_definitions.keys_breadth_first():
+            try:
+                if option_definitions[key].is_argument \
+                   and key not in switches_already_used:
+                   yield key
+            except AttributeError:
+                # this option definition does have the concept of being
+                # an argument - likely an aggregation 
+                pass


### PR DESCRIPTION
This change to configman adds named arguments.      

```
$ some_app.py  --help
usage:
   some_app.py [OPTIONS]...  arg1 [ arg2 [ arg3 ]]
```

It's the arg1, arg2, arg3 that I'm interested in here. Normally, you'd access these with sys.args without configman or config.args with configman. They come to the programmer as an uninterpreted list of strings. I'm treating them just like switches. The end result to the programmer looks like this:

```
config = config_manager.get_config()
print config.arg1, config.arg2, config.arg3
```

In other words, from the programmers perspective, they're just values passed into the program with the same access method and priority as command line switches. In fact,  the configman Option object is used to specify both switches and arguments: 

```
n.add_option(
    name='filename',
    doc='the name of the file',
    default=None,
    is_argument=True
)
```

see http://www.twobraids.com/2013/03/named-arguments-for-configman.html for more details
