### PR TITLE
fix excessive quotes in generating ini files

### DIFF
--- a/configman/converters.py
+++ b/configman/converters.py
@@ -261,6 +261,8 @@ def classes_in_namespaces_converter(template_for_namespace="cls%d",
         generated."""
         if isinstance(class_list_str, basestring):
             class_list = [x.strip() for x in class_list_str.split(',')]
+            if class_list == ['']:
+                class_list = []
         else:
             raise TypeError('must be derivative of a basestring')
 

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -816,6 +816,7 @@ c.string =   from ini
              ('admin.print_conf', 'print_conf', None),
              ('admin.dump_conf', 'dump_conf', ''),
              ('admin.conf', 'conf', None),
+             ('admin.migration', 'migration', False),
              ('application', 'application', MyApp),
              ('password', 'password', 'fred'),
              ('sub.name', 'name', 'ethel')])
@@ -1573,4 +1574,4 @@ c.string =   from ini
             self.assertTrue(
                 isinstance(cm.option_definitions[an_opt], Option)
             )
-        self.assertTrue(len(opts) == 8)  # there should be exactly 8 options
+        self.assertTrue(len(opts) == 9)  # there must be exactly 9 options

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -75,8 +75,8 @@ else:
             n.c.add_option('fred', 'stupid, deadly', 'husband from Flintstones')
             n.c.add_option('wilma', "waspish's", 'wife from Flintstones')
             n.d = config_manager.Namespace(doc='d space')
-            n.d.add_option('fred', "'''crabby'''", 'male neighbor from I Love Lucy')
-            n.d.add_option('ethel', '"""silly"""',
+            n.d.add_option('fred', "crabby", 'male neighbor from I Love Lucy')
+            n.d.add_option('ethel', 'silly',
                            'female neighbor from I Love Lucy')
             n.x = config_manager.Namespace(doc='x space')
             n.x.add_option('size', 100, 'how big in tons', short_form='s')
@@ -187,6 +187,8 @@ bad_option=bar  # other comment
 """# name: aaa
 # doc: the a
 # converter: configman.datetime_util.datetime_from_ISO_string
+# Inspect the automatically written value below to make sure it is valid
+#   as a Python object for its intended converter function.
 aaa='2011-05-04T15:10:00'
 
 [c]
@@ -199,31 +201,31 @@ aaa='2011-05-04T15:10:00'
     # name: wilma
     # doc: wife from Flintstones
     # converter: str
-    wilma="waspish's"
+    wilma=waspish's
 
 [d]
 
     # name: ethel
     # doc: female neighbor from I Love Lucy
     # converter: str
-    ethel='\"\"\"silly\"\"\"'
+    ethel=silly
 
     # name: fred
     # doc: male neighbor from I Love Lucy
     # converter: str
-    fred="\'\'\'crabby\'\'\'"
+    fred=crabby
 
 [x]
 
     # name: password
     # doc: the password
     # converter: str
-    password='secret "message"'
+    password=secret "message"
 
     # name: size
     # doc: how big in tons
     # converter: int
-    size='100'
+    size=100
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
@@ -231,13 +233,13 @@ aaa='2011-05-04T15:10:00'
             out.close()
             self.assertEqual(expected.strip(), received.strip())
 
-        # this test will be used in the future...
-        def donttest_write_ini_with_migration(self):
+        def test_write_ini_with_migration(self):
             n = self._some_namespaces()
             n.namespace('o')
             n.o.add_option('password', 'secret "message"', 'the password')
             c = config_manager.ConfigurationManager(
               [n],
+              [{'migration': True}],
               use_admin_controls=True,
               use_auto_help=False,
               argv_source=[]
@@ -246,12 +248,16 @@ aaa='2011-05-04T15:10:00'
 """# name: aaa
 # doc: the a
 # converter: configman.datetime_util.datetime_from_ISO_string
+# Inspect the automatically written value below to make sure it is valid
+#   as a Python object for its intended converter function.
 aaa='2011-05-04T15:10:00'
 
 # name: password
 # doc: the password
 # converter: str
-password='secret "message"'
+# The following value is common for more than one section below. Its value
+#   may be set here for all or it can be overridden in its original section
+password=secret "message"
 
 [c]
 
@@ -263,38 +269,155 @@ password='secret "message"'
     # name: wilma
     # doc: wife from Flintstones
     # converter: str
-    wilma="waspish's"
+    wilma=waspish's
 
 [d]
 
     # name: ethel
     # doc: female neighbor from I Love Lucy
     # converter: str
-    ethel='\"\"\"silly\"\"\"'
+    ethel=silly
 
     # name: fred
     # doc: male neighbor from I Love Lucy
     # converter: str
-    fred="\'\'\'crabby\'\'\'"
+    fred=crabby
 
 [o]
 
     # name: password
     # doc: the password
     # converter: str
-    # password='secret "message"'
+    # The following value has been automatically commented out because
+    #   the option is found in other sections and the defaults are the same.
+    #   The common value can be found in the lowest level section. Uncomment
+    #   to override that lower level value
+    #password=secret "message"
 
 [x]
 
     # name: password
     # doc: the password
     # converter: str
-    # password='secret "message"'
+    # The following value has been automatically commented out because
+    #   the option is found in other sections and the defaults are the same.
+    #   The common value can be found in the lowest level section. Uncomment
+    #   to override that lower level value
+    #password=secret "message"
 
     # name: size
     # doc: how big in tons
     # converter: int
-    size='100'
+    size=100
+"""
+            out = StringIO()
+            c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
+            received = out.getvalue()
+            out.close()
+            self.assertEqual(expected.strip(), received.strip())
+
+            values = c.get_config()
+            self.assertEqual(values.x.size, 100)
+            self.assertEqual(values.x.password, 'secret "message"')
+            self.assertEqual(values.o.password, 'secret "message"')
+            self.assertRaises(
+                KeyError,
+                lambda: values.d.password =='secret "message"'
+            )
+            self.assertRaises(
+                KeyError,
+                lambda: values.password =='secret "message"'
+            )
+
+            # try the round trip
+            tmp_filename = os.path.join(tempfile.gettempdir(), 'test.ini')
+            open(tmp_filename, 'w').write(received)
+            try:
+                c = config_manager.ConfigurationManager(
+                  [n],
+                  [tmp_filename],
+                  use_admin_controls=True,
+                  use_auto_help=False,
+                  argv_source=[]
+                )
+                values = c.get_config()
+                self.assertEqual(values.x.size, 100)
+                self.assertEqual(values.x.password, 'secret "message"')
+                self.assertEqual(values.o.password, 'secret "message"')
+                self.assertRaises(
+                    KeyError,
+                    lambda: values.d.password =='secret "message"'
+                )
+                self.assertRaises(
+                    KeyError,
+                    lambda: values.password =='secret "message"'
+                )
+            finally:
+                if os.path.isfile(tmp_filename):
+                    os.remove(tmp_filename)
+
+
+        def test_write_ini_with_migration_turned_off(self):
+            n = self._some_namespaces()
+            n.namespace('o')
+            n.o.add_option('password', 'secret "message"', 'the password')
+            c = config_manager.ConfigurationManager(
+              [n],
+              values_source_list=[{'admin.migration': False}],
+              use_admin_controls=True,
+              use_auto_help=False,
+              argv_source=[]
+            )
+            expected = \
+"""# name: aaa
+# doc: the a
+# converter: configman.datetime_util.datetime_from_ISO_string
+# Inspect the automatically written value below to make sure it is valid
+#   as a Python object for its intended converter function.
+aaa='2011-05-04T15:10:00'
+
+[c]
+
+    # name: fred
+    # doc: husband from Flintstones
+    # converter: str
+    fred='stupid, deadly'
+
+    # name: wilma
+    # doc: wife from Flintstones
+    # converter: str
+    wilma=waspish's
+
+[d]
+
+    # name: ethel
+    # doc: female neighbor from I Love Lucy
+    # converter: str
+    ethel=silly
+
+    # name: fred
+    # doc: male neighbor from I Love Lucy
+    # converter: str
+    fred=crabby
+
+[o]
+
+    # name: password
+    # doc: the password
+    # converter: str
+    password=secret "message"
+
+[x]
+
+    # name: password
+    # doc: the password
+    # converter: str
+    password=secret "message"
+
+    # name: size
+    # doc: how big in tons
+    # converter: int
+    size=100
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -221,9 +221,41 @@ class ValueSource(object):
                 option_value = option_value.encode('utf8')
 
             if an_option.comment_out:
-                option_format = '%s#%s=%r\n'
+                option_format = '%s#%s=%s\n'
+                print >>output_stream, "%s# The following value has been " \
+                    "automatically commented out because"  % indent_spacer
+                print >>output_stream, "%s#   the option is found in other " \
+                    "sections and the defaults are the same." % indent_spacer
+                print >>output_stream, "%s#   The common value can be found " \
+                    "in the lowest level section. Uncomment"  % indent_spacer
+                print >>output_stream, "%s#   to override that lower level " \
+                    "value" % indent_spacer
             else:
-                option_format = '%s%s=%r\n'
+                option_format = '%s%s=%s\n'
+
+            repr_for_converter = repr(an_option.from_string_converter)
+            if (
+                repr_for_converter.startswith('<function') or
+                repr_for_converter.startswith('<built-in')
+            ):
+                option_value = repr(option_value)
+                print >>output_stream, "%s# Inspect the automatically " \
+                    "written value below to make sure it is valid" \
+                    % indent_spacer
+                print >>output_stream, "%s#   as a Python object for its " \
+                    "intended converter function." % indent_spacer
+            elif an_option.from_string_converter is str:
+                if ',' in option_value or '\n' in option_value:
+                    option_value = repr(option_value)
+
+            if an_option.not_for_definition:
+                print >>output_stream, "%s# The following value is common " \
+                    "for more than one section below. Its value" \
+                    % indent_spacer
+                print >>output_stream, "%s#   may be set here for all or " \
+                    "it can be overridden in its original section" \
+                    % indent_spacer
+
             print >>output_stream, option_format % (
               indent_spacer,
               an_option.name,


### PR DESCRIPTION
when writing ini files, the handler for ConfigObj writes out an ini file with too many quotes.  This patch silences the excessive quoting, adds annotations to migrated options in ini files and adds an option to turn off migration.  
