### PR TITLE
fix missing key in DotDict copy constructor

### DIFF
--- a/configman/dotdict.py
+++ b/configman/dotdict.py
@@ -106,8 +106,14 @@ class DotDict(collections.MutableMapping):
                           mapping."""
         self.__dict__['_key_order'] = []
         if isinstance(initializer, collections.Mapping):
-            for key, value in iteritems_breadth_first(initializer):
-                self[key] = value
+            for key, value in iteritems_breadth_first(
+                initializer,
+                include_dicts=True
+            ):
+                if isinstance(value, collections.Mapping):
+                    self[key] = self.__class__(value)
+                else:
+                    self[key] = value
         elif initializer is not None:
             raise TypeError('can only initialize with a Mapping')
 

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -342,12 +342,21 @@ class TestCase(unittest.TestCase):
         # try a round trip
         dd = DotDict()
         for k, v in a:
-            print k, v
             dd.assign(k, v)
         ddkv = sorted(iteritems_breadth_first(dd))
         self.assertEqual(e, ddkv)
 
-    def  test_copy_constructor(self):
+
+    def test_copy_constructor_1(self):
+        d = {'d': {'x': 10}}
+        dd = DotDict(d)
+        self.assertTrue('d' in dd)
+        d = {'d': {}}
+        dd = DotDict(d)
+        self.assertTrue('d' in dd)
+
+
+    def  test_copy_constructor_2(self):
         d = {'a': {'aa': 13,
                    'ab': 14,},
              'b': {'ba': {'baa': 0,


### PR DESCRIPTION
When the DotDict **init** is called with a Mapping that has a key/value where the value is an empty Mapping, the key is missing from the resultant DotDict instance.  This fixes that oversight.  
