### PR TITLE
fixes issue 92: command line value sources now ignore --admin.strict and are always strict

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -624,9 +624,23 @@ class ConfigurationManager(object):
                 # ok, this values source doesn't have the concept
                 # always igoring mismatches, we won't tolerate mismatches
                 pass
+            # we want to fetch the keys from the value sources so that we can
+            # check for mismatches.  Commandline value sources, are different,
+            # we never want to allow unmatched keys from the command line.
+            # By detecting if this value source is a command line source, we
+            # can employ the command line's own mismatch detection.  The
+            # boolean 'allow_mismatches' controls application of the tollerance
+            # for mismatches.
+            if hasattr(a_value_source, 'command_line_value_source'):
+                allow_mismatches = False
+            else:
+                allow_mismatches = True
             # make a set of all the keys from a value source in the form
             # of strings like this: 'x.y.z'
-            value_source_mapping = a_value_source.get_values(self, True)
+            value_source_mapping = a_value_source.get_values(
+                self,
+                allow_mismatches
+            )
             value_source_keys_set = set([
                 k for k in
                 DotDict(value_source_mapping).keys_breadth_first()

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -1394,7 +1394,7 @@ c.string =   from ini
             config_manager.ConfigurationManager,
             rc,
             [{'admin': {'strict': True}},
-             {'source': {'clos': 'configman.tests.test_config_manager.T2'},
+             {'source': {'cls': 'configman.tests.test_config_manager.T2'},
               'destination': {'cls': 'configman.tests.test_config_manager.T3'}},
              {'source': {'cls': 'configman.tests.test_config_manager.T1'},
                          'destination': {'cls': 'configman.tests.test_config_manager.T2'}},
@@ -1407,7 +1407,7 @@ c.string =   from ini
             config_manager.ConfigurationManager,
             rc,
             [{'admin': {'strict': True}},
-             {'source': {'clos': 'configman.tests.test_config_manager.T2'},
+             {'source': {'cls': 'configman.tests.test_config_manager.T2'},
               'destination': {'cls': 'configman.tests.test_config_manager.T3'}},
              {'sourness': {'cls': 'configman.tests.test_config_manager.T1'},
                          'destination': {'cls': 'configman.tests.test_config_manager.T2'}},
@@ -1415,6 +1415,27 @@ c.string =   from ini
                          'destination': {'cls': 'configman.tests.test_config_manager.T1'}},
             ],
         )
+
+        # make sure commandline data sources always behave stictly even when
+        # strict is set to False
+        import getopt
+        self.assertRaises( #  'alpha' is not an option
+            NotAnOptionError,
+            config_manager.ConfigurationManager,
+            rc,
+            [{'admin': {'strict': False}},  # not strict, we allow anything
+             {'source': {'cls': 'configman.tests.test_config_manager.T2'},
+              'destination': {'cls': 'configman.tests.test_config_manager.T3'}},
+             {'source': {'cls': 'configman.tests.test_config_manager.T1'},
+                         'destination': {'cls': 'configman.tests.test_config_manager.T2'}},
+             # commandline sources need to ignore when strict=False and raise
+             # NotAnOptionError anyway - we don't want to allow arbitrary
+             # switches on the command line.
+             getopt,
+            ],
+            argv_source=['--alpha']
+        )
+
 
     def test_acquisition(self):
         """define a common key in two sub-namespaces.  Then offer only a value

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -78,6 +78,14 @@ class ValueSource(object):
         else:
             raise CantHandleTypeException()
 
+    # frequently, command line data sources must be treated differently.  For
+    # example, even when the overall option for configman is to allow
+    # non-strict option matching, the command line should not arbitrarily
+    # accept bad command line switches.  The existance of this key will make
+    # sure that a bad command line switch will result in an error without
+    # regard to the overall --admin.strict setting.
+    command_line_value_source = True
+
     def get_values(self, config_manager, ignore_mismatches):
         """This is the black sheep of the crowd of ValueSource implementations.
         It needs to know ahead of time all of the parameters that it will need,
@@ -236,5 +244,5 @@ class ValueSource(object):
                    yield key
             except AttributeError:
                 # this option definition does have the concept of being
-                # an argument - likely an aggregation 
+                # an argument - likely an aggregation
                 pass


### PR DESCRIPTION
the implementation of the --admin.strict switch had the unintended side effect of stopping the command line from checking the validity of its switches.  It is my belief that, while we may allow unknown keys in ini files, we should never allow unknown keys at the command line.   

This PR fixes that issue.
