### PR TITLE
the referenced_value project

### DIFF
--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -45,6 +45,7 @@ class Namespace(dotdict.DotDict):
     def __init__(self, doc=''):
         super(Namespace, self).__init__()
         object.__setattr__(self, '_doc', doc)  # force into attributes
+        object.__setattr__(self, '_reference_value_from', False)
 
     #--------------------------------------------------------------------------
     def __setattr__(self, name, value):
@@ -57,8 +58,26 @@ class Namespace(dotdict.DotDict):
 
     #--------------------------------------------------------------------------
     def add_option(self, name, *args, **kwargs):
-        an_option = Option(name, *args, **kwargs)
-        setattr(self, name, an_option)
+        """add an option to the namespace.   This can take two forms:
+              'name' is a string representing the name of an option and the
+              kwargs are its parameters, or 'name' is an instance of an Option
+              object
+        """
+        if isinstance(name, Option):
+            an_option = name
+            name = an_option.name
+        else:
+            an_option = Option(name, *args, **kwargs)
+
+        current_namespace = self
+        name_parts = name.split('.')
+        for a_path_component in name_parts[:-1]:
+            if a_path_component not in current_namespace:
+                current_namespace[a_path_component] = Namespace()
+            current_namespace = current_namespace[a_path_component]
+        an_option.name = name_parts[-1]
+
+        setattr(current_namespace, an_option.name, an_option)
 
     #--------------------------------------------------------------------------
     def add_aggregation(self, name, function):
@@ -89,6 +108,8 @@ class Namespace(dotdict.DotDict):
     #--------------------------------------------------------------------------
     def safe_copy(self):
         new_namespace = Namespace()
+        if self._reference_value_from:
+            new_namespace.tag_as_reference_value_from()
         for key, opt in self.iteritems():
             if isinstance(opt, Option):
                 new_namespace[key] = opt.copy()
@@ -100,3 +121,10 @@ class Namespace(dotdict.DotDict):
             elif isinstance(opt, Namespace):
                 new_namespace[key] = opt.safe_copy()
         return new_namespace
+
+    #--------------------------------------------------------------------------
+    def tag_as_reference_value_from(self):
+        """tag this namespace as having been created by the reference_value_from
+        system for collecting common resources together."""
+        object.__setattr__(self, '_reference_value_from', True)  # force into attributes
+

--- a/configman/option.py
+++ b/configman/option.py
@@ -58,6 +58,7 @@ class Option(object):
                  is_argument=False,
                  comment_out=False,
                  not_for_definition=False,
+                 reference_value_from=None,
                  ):
         self.name = name
         self.short_form = short_form
@@ -81,6 +82,7 @@ class Option(object):
         self.exclude_from_dump_conf = exclude_from_dump_conf
         self.comment_out = comment_out
         self.not_for_definition = not_for_definition
+        self.reference_value_from = reference_value_from
 
     #--------------------------------------------------------------------------
     def __str__(self):
@@ -205,6 +207,7 @@ class Option(object):
             is_argument=self.is_argument,
             comment_out=self.comment_out,
             not_for_definition=self.not_for_definition,
+            reference_value_from=self.reference_value_from
         )
         return o
 

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -461,6 +461,47 @@ c.string =   from ini
         self.assertEqual(c.option_definitions.c.string.default, 'from ini')
         self.assertEqual(c.option_definitions.c.string.value, 'from ini')
 
+    def test_overlay_config_11(self):
+        """test overlay dict w/deep source dict and reference value links"""
+        n = config_manager.Namespace()
+        n.add_option('a', 1, doc='the a', reference_value_from='xxx.yyy')
+        n.b = 17
+        n.c = config_manager.Namespace()
+        n.c.add_option(
+            'extra', doc='the x',
+            default=3.14159,
+            reference_value_from='xxx.yyy'
+        )
+        n.c.add_option(
+            'a',
+            doc='the a',
+            reference_value_from='xxx.yyy'
+        )
+        g = {
+            'xxx': {
+                'yyy': {
+                    'a': 2,
+                    'extra': 2.89
+                }
+            }
+         }
+        c = config_manager.ConfigurationManager([n], [g],
+                                    use_admin_controls=True,
+                                    #use_config_files=False,
+                                    use_auto_help=False,
+                                    argv_source=[])
+        self.assertTrue(isinstance(c.option_definitions.b,
+                                   config_manager.Option))
+        self.assertEqual(c.option_definitions.a.value, 2)
+        self.assertEqual(c.option_definitions.b.value, 17)
+        self.assertEqual(c.option_definitions.b.default, 17)
+        self.assertEqual(c.option_definitions.b.name, 'b')
+        self.assertEqual(c.option_definitions.c.extra.name, 'extra')
+        self.assertEqual(c.option_definitions.c.extra.doc, 'the x')
+        self.assertEqual(c.option_definitions.c.extra.default, 2.89)
+        self.assertEqual(c.option_definitions.c.extra.value, 2.89)
+        self.assertEqual(c.option_definitions.c.a.value, 2)
+
     def test_mapping_types_1(self):
         n = config_manager.Namespace()
         n.add_option(

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -43,6 +43,8 @@ import functools
 import configman.config_manager as config_manager
 import configman.datetime_util as dtu
 
+from configman.option import Option
+
 
 class TestCase(unittest.TestCase):
 
@@ -248,4 +250,8 @@ class TestCase(unittest.TestCase):
         n4 = deepcopy(n)
         self.assertTrue(n.a is not n4.a)
 
-
+    def test_add_option_with_option(self):
+        o = Option('dwight')
+        n = config_manager.Namespace()
+        n.add_option(o)
+        self.assertTrue(o is n.dwight)

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -413,3 +413,28 @@ class TestCase(unittest.TestCase):
 
         # FIXME: need a way to test a value whose 'from_string_converter'
         # requires quotes
+
+    def test_reference_value_from(self):
+        o1 = Option(
+            name='fred',
+            reference_value_from='external.postgresql'
+        )
+        self.assertEqual(o1.reference_value_from, 'external.postgresql')
+
+    def test_copy(self):
+        o = Option(
+            name='dwight',
+            default=17,
+            doc='the doc',
+            from_string_converter=int,
+            value=0,
+            short_form='d',
+            exclude_from_print_conf=True,
+            exclude_from_dump_conf=True,
+            is_argument=False,
+            comment_out=False,
+            not_for_definition=False,
+            reference_value_from='external.postgresql'
+        )
+        o2 = o.copy()
+        self.assertEqual(o, o2)

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -275,8 +275,9 @@ password=secret "message"
     # doc: the password
     # The following value has been automatically commented out because
     #   the option is found in other sections and the defaults are the same.
-    #   The common value can be found in the lowest level section. Uncomment
-    #   to override that lower level value
+    #   The common value can be found in the lowest level of this file.
+    #   You may uncomment this value to override the value from the
+    #   alternate location
     #password=secret "message"
 
 [x]
@@ -285,8 +286,9 @@ password=secret "message"
     # doc: the password
     # The following value has been automatically commented out because
     #   the option is found in other sections and the defaults are the same.
-    #   The common value can be found in the lowest level section. Uncomment
-    #   to override that lower level value
+    #   The common value can be found in the lowest level of this file.
+    #   You may uncomment this value to override the value from the
+    #   alternate location
     #password=secret "message"
 
     # name: size
@@ -339,13 +341,27 @@ password=secret "message"
                 if os.path.isfile(tmp_filename):
                     os.remove(tmp_filename)
 
-        def test_write_ini_with_migration_turned_off(self):
+        def test_write_ini_with_reference_value_froms_and_migration_turned_off(
+            self
+        ):
             n = self._some_namespaces()
-            n.namespace('o')
-            n.o.add_option('password', 'secret "message"', 'the password')
+            n.namespace('x1')
+            n.x1.add_option('password', 'secret "message"', 'the password',
+                           reference_value_from='xxx.yyy')
+            n.namespace('x2')
+            n.x2.add_option('password', 'secret "message"', 'the password',
+                           reference_value_from='xxx.yyy')
+            external_values = {
+                'admin.migration': False,
+                'xxx': {
+                    'yyy': {
+                        'password': 'dwight and wilma'
+                    }
+                }
+            }
             c = config_manager.ConfigurationManager(
               [n],
-              values_source_list=[{'admin.migration': False}],
+              values_source_list=[external_values],
               use_admin_controls=True,
               use_auto_help=False,
               argv_source=[]
@@ -356,6 +372,30 @@ password=secret "message"
 # Inspect the automatically written value below to make sure it is valid
 #   as a Python object for its intended converter function.
 aaa='2011-05-04T15:10:00'
+
+[xxx]
+
+    # this section contains Options that are common in
+    # other sections of this ini file.  If they are used
+    # in other files too, copy the options to the file
+    # in the +include line below.  Comment out the values
+    # in the Options.  Finally uncomment the +include line.
+
+    #+include ./common_xxx.ini
+
+    [[yyy]]
+
+        # this section contains Options that are common in
+        # other sections of this ini file.  If they are used
+        # in other files too, copy the options to the file
+        # in the +include line below.  Comment out the values
+        # in the Options.  Finally uncomment the +include line.
+
+        #+include ./common_yyy.ini
+
+        # name: password
+        # doc: the password
+        password=dwight and wilma
 
 [c]
 
@@ -377,12 +417,6 @@ aaa='2011-05-04T15:10:00'
     # doc: male neighbor from I Love Lucy
     fred=crabby
 
-[o]
-
-    # name: password
-    # doc: the password
-    password=secret "message"
-
 [x]
 
     # name: password
@@ -392,6 +426,29 @@ aaa='2011-05-04T15:10:00'
     # name: size
     # doc: how big in tons
     size=100
+
+[x1]
+
+    # name: password
+    # doc: the password
+    # The following value has been automatically commented out because
+    #   it is linked to another option. see:
+    #   x1.password -> xxx.yyy.password
+    #   You may uncomment this value to override the value from the
+    #   alternate location
+    #password=dwight and wilma
+
+[x2]
+
+    # name: password
+    # doc: the password
+    # The following value has been automatically commented out because
+    #   it is linked to another option. see:
+    #   x2.password -> xxx.yyy.password
+    #   You may uncomment this value to override the value from the
+    #   alternate location
+    #password=dwight and wilma
+
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))


### PR DESCRIPTION
This is the implementation of the resource branch outlined in my blog posting http://www.twobraids.com/2013/11/configuration-is-eating-my-brain.html  I would really like to see this system integrated into configman.  We may choose not to use it, just like we're not using the migration feature.   Since configman is a system that is not used outside of Socorro, except for a few personal projects, I think we can afford to be exploratory: we should try different things.  This may prove to be very useful, or, like the migration feature, may fall flat on its face.  We can always back it out later if gets in the way.  
