### PR TITLE
fixed overlay bug and added test to verify

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -598,6 +598,13 @@ class ConfigurationManager(object):
                     if current_namespace is None:
                         # we're at the top level, use the base namespace
                         current_namespace = self.option_definitions
+                    # some new Options to be brought in may have already been
+                    # seen and in the known_keys set.  They must be marked 
+                    # as unseen so that the new default doesn't overwrite any
+                    # of the overlays that have already taken place.
+                    known_keys = known_keys.difference(
+                        known_keys.intersection(new_req.keys())
+                    )
                     # add the new Options to the namespace
                     current_namespace.update(new_req.safe_copy(
                         an_option.reference_value_from

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -1602,3 +1602,31 @@ c.string =   from ini
             )
         finally:
             os.remove('x.ini')
+
+    def test_overlay_bug(self):
+        # for Options that already exist and have been seen by the overlay 
+        # process, make sure that expanding a class doesn't just overwrite
+        # the values back to their original defaults
+        
+        r = Namespace()
+        r.add_option('fred', default=0)
+        r.add_option(
+            'class', 
+            default=int, 
+            from_string_converter=class_converter
+        )
+        
+        # this class will bring in an Option that already exists called "fred".
+        # Since overlay is done before expansion, "fred" should get set to 99.
+        # Then expansion will bring in A's "fred" with a value of 77.  We need
+        # make sure that the overlay process then puts its back to 99.
+        class A(RequiredConfig):
+            required_config = Namespace()
+            required_config.add_option('fred', default='77')
+        
+        cm = config_manager.ConfigurationManager(
+            [r], 
+            [{'fred': 21}, {'class': A}, {'fred': 99}]
+        )
+        cn = cm.get_config()
+        self.assertEqual(cn.fred, 99)


### PR DESCRIPTION
there's a bug in the overlay/expand process.  If an expansion of a class brings in new Options, but one of those options already exists in the namespace, that pre-existing option will be overwritten with the defaults from the expanded class.  That's true, even when that overwitten option has already been through the overlay process.  In otherwords, the expansion resets the option back to its default value, cancelling any values that might have come in from the commandline, ini file, etc.  

The solution is to look at what is brought in by an expansion of a class.  If the Option have "already been seen", mark that option as "new" so that the overlay process can restore the value.
