### PR TITLE
default ini to all option values commented out except those marked otherwise.

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -477,7 +477,6 @@ class ConfigurationManager(object):
                 and an_option.reference_value_from not in known_keys
             ):
                 alt_option = an_option.copy()
-                an_option.comment_out = True
                 alt_option.reference_value_from = None
                 alt_option.name = '.'.join(
                     (an_option.reference_value_from, alt_option.name)

--- a/configman/option.py
+++ b/configman/option.py
@@ -56,7 +56,7 @@ class Option(object):
                  exclude_from_print_conf=False,
                  exclude_from_dump_conf=False,
                  is_argument=False,
-                 comment_out=False,
+                 likely_to_be_changed=False,
                  not_for_definition=False,
                  reference_value_from=None,
                  ):
@@ -80,7 +80,7 @@ class Option(object):
         self.is_argument = is_argument
         self.exclude_from_print_conf = exclude_from_print_conf
         self.exclude_from_dump_conf = exclude_from_dump_conf
-        self.comment_out = comment_out
+        self.likely_to_be_changed = likely_to_be_changed
         self.not_for_definition = not_for_definition
         self.reference_value_from = reference_value_from
 
@@ -205,7 +205,7 @@ class Option(object):
             exclude_from_print_conf=self.exclude_from_print_conf,
             exclude_from_dump_conf=self.exclude_from_dump_conf,
             is_argument=self.is_argument,
-            comment_out=self.comment_out,
+            likely_to_be_changed=self.likely_to_be_changed,
             not_for_definition=self.not_for_definition,
             reference_value_from=self.reference_value_from
         )

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -432,7 +432,7 @@ class TestCase(unittest.TestCase):
             exclude_from_print_conf=True,
             exclude_from_dump_conf=True,
             is_argument=False,
-            comment_out=False,
+            likely_to_be_changed=False,
             not_for_definition=False,
             reference_value_from='external.postgresql'
         )

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -183,41 +183,32 @@ bad_option=bar  # other comment
               argv_source=[]
             )
             expected = \
-"""# name: aaa
-# doc: the a
-# Inspect the automatically written value below to make sure it is valid
-#   as a Python object for its intended converter function.
-aaa='2011-05-04T15:10:00'
+"""# the a
+#aaa='2011-05-04T15:10:00'
 
 [c]
 
-    # name: fred
-    # doc: husband from Flintstones
-    fred='stupid, deadly'
+    # husband from Flintstones
+    #fred='stupid, deadly'
 
-    # name: wilma
-    # doc: wife from Flintstones
-    wilma=waspish's
+    # wife from Flintstones
+    #wilma=waspish's
 
 [d]
 
-    # name: ethel
-    # doc: female neighbor from I Love Lucy
-    ethel=silly
+    # female neighbor from I Love Lucy
+    #ethel=silly
 
-    # name: fred
-    # doc: male neighbor from I Love Lucy
-    fred=crabby
+    # male neighbor from I Love Lucy
+    #fred=crabby
 
 [x]
 
-    # name: password
-    # doc: the password
-    password=secret "message"
+    # the password
+    #password=secret "message"
 
-    # name: size
-    # doc: how big in tons
-    size=100
+    # how big in tons
+    #size=100
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
@@ -230,11 +221,20 @@ aaa='2011-05-04T15:10:00'
         ):
             n = self._some_namespaces()
             n.namespace('x1')
-            n.x1.add_option('password', 'secret "message"', 'the password',
-                           reference_value_from='xxx.yyy')
+            n.x1.add_option(
+                'password',
+                default='secret "message"',
+                doc='the password',
+                likely_to_be_changed=True,
+                reference_value_from='xxx.yyy'
+            )
             n.namespace('x2')
-            n.x2.add_option('password', 'secret "message"', 'the password',
-                           reference_value_from='xxx.yyy')
+            n.x2.add_option(
+                'password',
+                default='secret "message"',
+                doc='the password',
+                reference_value_from='xxx.yyy'
+            )
             external_values = {
                 'xxx': {
                     'yyy': {
@@ -250,88 +250,55 @@ aaa='2011-05-04T15:10:00'
               argv_source=[]
             )
             expected = \
-"""# name: aaa
-# doc: the a
-# Inspect the automatically written value below to make sure it is valid
-#   as a Python object for its intended converter function.
-aaa='2011-05-04T15:10:00'
+"""# the a
+#aaa='2011-05-04T15:10:00'
 
 [xxx]
-
-    # this section contains Options that are common in
-    # other sections of this ini file.  If they are used
-    # in other files too, copy the options to the file
-    # in the +include line below.  Comment out the values
-    # in the Options.  Finally uncomment the +include line.
 
     #+include ./common_xxx.ini
 
     [[yyy]]
 
-        # this section contains Options that are common in
-        # other sections of this ini file.  If they are used
-        # in other files too, copy the options to the file
-        # in the +include line below.  Comment out the values
-        # in the Options.  Finally uncomment the +include line.
-
         #+include ./common_yyy.ini
 
-        # name: password
-        # doc: the password
-        password=dwight and wilma
+        # the password
+        #password=dwight and wilma
 
 [c]
 
-    # name: fred
-    # doc: husband from Flintstones
-    fred='stupid, deadly'
+    # husband from Flintstones
+    #fred='stupid, deadly'
 
-    # name: wilma
-    # doc: wife from Flintstones
-    wilma=waspish's
+    # wife from Flintstones
+    #wilma=waspish's
 
 [d]
 
-    # name: ethel
-    # doc: female neighbor from I Love Lucy
-    ethel=silly
+    # female neighbor from I Love Lucy
+    #ethel=silly
 
-    # name: fred
-    # doc: male neighbor from I Love Lucy
-    fred=crabby
+    # male neighbor from I Love Lucy
+    #fred=crabby
 
 [x]
 
-    # name: password
-    # doc: the password
-    password=secret "message"
+    # the password
+    #password=secret "message"
 
-    # name: size
-    # doc: how big in tons
-    size=100
+    # how big in tons
+    #size=100
 
 [x1]
 
-    # name: password
-    # doc: the password
-    # The following value has been automatically commented out because
-    #   it is linked to another option. see:
-    #   x1.password -> xxx.yyy.password
-    #   You may uncomment this value to override the value from the
-    #   alternate location
-    #password=dwight and wilma
+    # the password
+    # see "xxx.yyy.password" for the default or override it here
+    password=dwight and wilma
 
 [x2]
 
-    # name: password
-    # doc: the password
-    # The following value has been automatically commented out because
-    #   it is linked to another option. see:
-    #   x2.password -> xxx.yyy.password
-    #   You may uncomment this value to override the value from the
-    #   alternate location
+    # the password
+    # see "xxx.yyy.password" for the default or override it here
     #password=dwight and wilma
-
 """
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
@@ -361,12 +328,7 @@ aaa='2011-05-04T15:10:00'
               use_auto_help=False,
               argv_source=[]
             )
-            expected = ("""# name: a
-# doc: the doc string
-# Inspect the automatically written value below to make sure it is valid
-#   as a Python object for its intended converter function.
-a='one:One'
-            """)
+            expected = "# the doc string\n#a='one:One'\n"
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
             received = out.getvalue()

--- a/configman/value_sources/for_conf.py
+++ b/configman/value_sources/for_conf.py
@@ -136,10 +136,10 @@ class ValueSource(object):
             if isinstance(option_value, unicode):
                 option_value = option_value.encode('utf8')
 
-            if an_option.comment_out:
-                option_format = '# %s=%r\n'
-            else:
+            if an_option.likely_to_be_changed:
                 option_format = '%s=%r\n'
+            else:
+                option_format = '# %s=%r\n'
             print >>output_stream, option_format % (
               option_name,
               option_value

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -211,55 +211,23 @@ class ValueSource(object):
         options.sort(cmp=lambda x, y: cmp(x.name, y.name))
         indent_spacer = " " * (level * indent_size)
         for an_option in options:
-            print >>output_stream, "%s# name: %s" % (indent_spacer,
-                                                     an_option.name)
-            print >>output_stream, "%s# doc: %s" % (indent_spacer,
-                                                    an_option.doc)
+            print >>output_stream, "%s# %s" % (indent_spacer, an_option.doc)
             option_value = str(an_option)
             if isinstance(option_value, unicode):
                 option_value = option_value.encode('utf8')
 
-            if an_option.comment_out:
-                option_format = '%s#%s=%s\n'
-                print >>output_stream, "%s# The following value has been " \
-                    "automatically commented out because"  % indent_spacer
-                if an_option.reference_value_from:
-                    print >>output_stream, (
-                        "%s#   it is linked to another "
-                        "option. see:" % indent_spacer
-                    )
-                    if namespace_name:
-                        print >>output_stream, (
-                            "%s#   %s.%s -> %s.%s"  %
-                            (indent_spacer, namespace_name, an_option.name,
-                             an_option.reference_value_from, an_option.name)
-                        )
-                    else:
-                        print >>output_stream, (
-                            "%s#   %s -> %s.%s"  %
-                            (indent_spacer, an_option.name,
-                             an_option.reference_value_from, an_option.name)
-                        )
+            if an_option.reference_value_from:
+                print >>output_stream, (
+                    '%s# see "%s.%s" for the default or override it here' %
+                        (indent_spacer, 
+                         an_option.reference_value_from, 
+                         an_option.name)
+                )
 
-                else:
-                    print >>output_stream, (
-                        "%s#   the option is found in other "
-                        "sections and the defaults are the same."
-                        % indent_spacer
-                    )
-                    print >>output_stream, (
-                        "%s#   The common value can be found "
-                        "in the lowest level of this file."  % indent_spacer
-                    )
-                print >>output_stream, (
-                    "%s#   You may uncomment this value to override the "
-                    "value from the" % indent_spacer
-                )
-                print >>output_stream, (
-                    "%s#   alternate location" % indent_spacer
-                )
-            else:
+            if an_option.likely_to_be_changed:
                 option_format = '%s%s=%s\n'
+            else:
+                option_format = '%s#%s=%s\n'
 
             repr_for_converter = repr(an_option.from_string_converter)
             if (
@@ -267,22 +235,9 @@ class ValueSource(object):
                 repr_for_converter.startswith('<built-in')
             ):
                 option_value = repr(option_value)
-                print >>output_stream, "%s# Inspect the automatically " \
-                    "written value below to make sure it is valid" \
-                    % indent_spacer
-                print >>output_stream, "%s#   as a Python object for its " \
-                    "intended converter function." % indent_spacer
             elif an_option.from_string_converter is str:
                 if ',' in option_value or '\n' in option_value:
                     option_value = repr(option_value)
-
-            if an_option.not_for_definition:
-                print >>output_stream, "%s# The following value is common " \
-                    "for more than one section below. Its value" \
-                    % indent_spacer
-                print >>output_stream, "%s#   may be set here for all or " \
-                    "it can be overridden in its original section" \
-                    % indent_spacer
 
             print >>output_stream, option_format % (
               indent_spacer,
@@ -310,27 +265,7 @@ class ValueSource(object):
                 )
             if namespace._reference_value_from:
                 print >>output_stream, (
-                    "%s# this section contains Options that are common in"
-                    % next_level_spacer
-                )
-                print >>output_stream, (
-                    "%s# other sections of this ini file.  If they are used"
-                    % next_level_spacer
-                )
-                print >>output_stream, (
-                    "%s# in other files too, copy the options to the file"
-                    % next_level_spacer
-                )
-                print >>output_stream, (
-                    "%s# in the +include line below.  Comment out the values"
-                    % next_level_spacer
-                )
-                print >>output_stream, (
-                    "%s# in the Options.  Finally uncomment the +include line."
-                    % next_level_spacer
-                )
-                print >>output_stream, (
-                    "\n%s#+include ./common_%s.ini\n"
+                    "%s#+include ./common_%s.ini\n"
                     % (next_level_spacer, key)
                 )
 

--- a/configman/value_sources/for_configparse.py
+++ b/configman/value_sources/for_configparse.py
@@ -153,10 +153,10 @@ class ValueSource(object):
             if isinstance(option_value, unicode):
                 option_value = option_value.encode('utf8')
 
-            if an_option.comment_out:
-                option_format = '# %s=%r\n'
-            else:
+            if an_option.likely_to_be_changed:
                 option_format = '%s=%r\n'
+            else:
+                option_format = '#%s=%r\n'
             print >>output_stream, option_format % (
               an_option.name,
               option_value


### PR DESCRIPTION
This PR represents a change to writing out ini files.

1) opinion has been that the comments about why something is commented out, or suggestions as to the use of include files is clutter that detracts rather than helps.  This PR drastically reduces the amount of comments in the ini file.

2) all values are now by default commented out.  The apps should be able to run with defaults.  Editing the ini file is only for special cases.

3) introduction of `likely_to_be_changed` keyword in the Option constructor.  This indicates that the Option is volatile and is very likely to be edited in the ini file:  passwords, host names, etc.   Options with this tag will not be commented out by default when writing the ini file.  
