### PR TITLE
fixed bug where ref_objects got overwritten

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -487,26 +487,33 @@ class ConfigurationManager(object):
         # a set of known reference_value_from_links
         set_of_reference_value_from_links = set()
         for key in (k for k in keys if k not in known_keys):
+
             an_option = self.option_definitions[key]
-            #if not isinstance(an_option, Option):  #TODO remove
-            #    continue  # aggregations and other types are ignored
-            if (
-                an_option.reference_value_from
-                and an_option.reference_value_from not in
-                    set_of_reference_value_from_links
-                and an_option.reference_value_from not in known_keys
-            ):
-                alt_option = an_option.copy()
-                alt_option.reference_value_from = None
-                alt_option.name = '.'.join(
-                    (an_option.reference_value_from, alt_option.name)
-                )
-                set_of_reference_value_from_links.add(alt_option.name)
-                self.option_definitions.add_option(alt_option)
+            if an_option.reference_value_from:
+
+                reference_name = '.'.join((
+                    an_option.reference_value_from,
+                    an_option.name
+                ))
+                if reference_name in self.option_definitions:
+                    continue  # this referenced value has already been defined
+                              # no need to repeat it - skip on to the next key
+                reference_option = an_option.copy()
+                reference_option.reference_value_from = None
+                reference_option.name = reference_name
+                # wait, aren't we setting a fully qualified dotted name into
+                # the name field?  Yes, 'add_option' below sees that
+                # full pathname and does the right thing with it to ensure
+                # that the reference_option is created within the
+                # correct namespace
+                set_of_reference_value_from_links.add(reference_option.name)
+                self.option_definitions.add_option(reference_option)
+
         for a_reference_value_from in set_of_reference_value_from_links:
             for x in range(a_reference_value_from.count('.')):
                 namespace_path = a_reference_value_from.rsplit('.', x + 1)[0]
                 self.option_definitions[namespace_path].ref_value_namespace()
+
         return set_of_reference_value_from_links
 
     #--------------------------------------------------------------------------

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -287,7 +287,7 @@ bad_option=bar  # other comment
         #+include ./common_yyy.ini
 
         # the password
-        #password=dwight and wilma
+        password=dwight and wilma
 
 [c]
 


### PR DESCRIPTION
When 'reference_options' are created for the use of 'reference_value_from' links, they are created without testing to see if they already exist.  That meant that sometimes when complicated class expansions happen, 'reference_options' can created earlier can get overwritten by 'reference_options' created later. 

Ensured that an existence check is made before new 'reference_options' are created.  Refactored some of the code to make it clearer.  Fixed a test that was hiding this problem.  Added another test for this problem.  
