### PR TITLE
fixed second bug that would overwrite the resource section

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -636,9 +636,12 @@ class ConfigurationManager(object):
                         known_keys.intersection(new_req.keys())
                     )
                     # add the new Options to the namespace
-                    current_namespace.update(new_req.safe_copy(
+                    new_namespace = new_req.safe_copy(
                         an_option.reference_value_from
-                    ))
+                    )
+                    for new_key in new_namespace.keys_breadth_first():
+                        if new_key not in current_namespace:
+                            current_namespace[new_key] = new_namespace[new_key]
                 except AttributeError, x:
                     # there are apparently no new Options to bring in from
                     # this option's value

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -1866,3 +1866,46 @@ c.string =   from ini
         )
         cn = cm.get_config()
         self.assertEqual(cn.fred, 99)
+
+    #--------------------------------------------------------------------------
+    def test_overlay_reference_value_from_bug_2(self):
+        # for Options that already exist and have been seen by the overlay
+        # process, make sure that expanding a class doesn't just overwrite
+        # the values back to their original defaults
+        class A(RequiredConfig):
+            required_config = Namespace()
+            required_config.add_option(
+                'fred',
+                default='77',
+                reference_value_from='a'
+            )
+
+        class B(RequiredConfig):
+            required_config = Namespace()
+            required_config.add_option(
+                'a_class',
+                default=A,
+                from_string_converter=class_converter,
+                reference_value_from='a'
+            )
+
+        r = Namespace()
+        r.add_option(
+            'some_class',
+            default=A,
+            from_string_converter=class_converter,
+            reference_value_from='a'
+        )
+        r.add_option(
+            'other_class',
+            default=A,
+            from_string_converter=class_converter,
+            reference_value_from='a'
+        )
+
+        cm = config_manager.ConfigurationManager(
+            [r],
+            [{'a.fred': 21}, {'other_class': B}]
+        )
+        cn = cm.get_config()
+        self.assertEqual(cn.fred, 21)


### PR DESCRIPTION
in the crontabber, the resource.rabbitmq.host kept getting overwritten back to 'localhost'.  This was because the expansion code in the `_overlay_expand` method would use an `update` on the namespace even if some of the keys already existed.  This has been changed to a more discriminate update that won't overwrite.   
