### PR TITLE
added acquisition to os.environ to enable shortcuts

### DIFF
--- a/configman/value_sources/for_mapping.py
+++ b/configman/value_sources/for_mapping.py
@@ -40,6 +40,7 @@ import collections
 import os
 
 from source_exceptions import CantHandleTypeException
+from configman.dotdict import DotDictWithAcquisition
 
 can_handle = (
     os.environ,
@@ -53,6 +54,7 @@ class ValueSource(object):
     def __init__(self, source, the_config_manager=None):
         if source is os.environ:
             self.always_ignore_mismatches = True
+            source = DotDictWithAcquisition(os.environ)
         elif isinstance(source, collections.Mapping):
             self.always_ignore_mismatches = False
         else:


### PR DESCRIPTION
versions of configman previous to 1.2.4 treated all incoming key/value value_sources as if they had acquisition.  I felt this lead to ambiguity and surprises as common names like 'password' matched unexpected in places.  For example:
- defined options:
  - a.b.password
  - a.c.password
- incoming value_source:
  - "password": "foopass"

configman would assign "foopass" to both a.b.password and a.c.password.

It turns out that crontabber and several features of Socorro elasticsearch tests relied on this feature that I removed.

This PR puts the feature back, but only for environment variables.  If a programmer wants the behavior for other key/value mappings, I suggest explicitly stating so by wrapping the mapping in the class `DotDictWithAcquisition`.  This fixes the crontabber project.   However, for the Socorro ES tests, I've made sure that they fully qualify their option names so there can be no ambiguity.  
