### PR TITLE
altered interpretation of environ

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -56,8 +56,12 @@ from .converters import class_converter, regex_converter, timedelta_converter
 
 # constants used to refer to Value Source concepts generically
 from config_file_future_proxy import ConfigFileFutureProxy
-from os import environ as environment
 import getopt as command_line
+
+from os import environ
+from .dotdict import configman_keys
+environment = configman_keys(environ)
+environment.always_ignore_mismatches = True
 
 
 #------------------------------------------------------------------------------

--- a/configman/dotdict.py
+++ b/configman/dotdict.py
@@ -58,6 +58,28 @@ def iteritems_breadth_first(a_mapping, include_dicts=False):
             yield '%s.%s' % (key, sub_key), value
 
 
+#------------------------------------------------------------------------------
+def configman_keys(a_mapping):
+    """return a DotDict that is a copy of the provided mapping with keys
+    transformed into a configman compatible form:
+     if the key is not all uppercase then
+        all doubled underscores will be replaced
+        with the '.' character.
+
+    This has a specific use with the os.environ.  Linux shells generally do not
+    allow the dot character in an identifier.  Configman relies on the
+    dot character to separate namespaces.  If the environment is processed
+    through this function, then doubled underscores will be interpretted as if
+    they were the dot character.
+    """
+    configmanized_keys_dict = DotDict()
+    for k, v in iteritems_breadth_first(a_mapping):
+        if '__' in k and k != k.upper():
+            k = k.replace('__', '.')
+        configmanized_keys_dict[k] = v
+    return configmanized_keys_dict
+
+
 #==============================================================================
 class DotDict(collections.MutableMapping):
     """This class is a mapping that stores its items within the __dict__

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -41,6 +41,7 @@ from configman.dotdict import (
     DotDict,
     DotDictWithAcquisition,
     iteritems_breadth_first,
+    configman_keys
 )
 
 
@@ -407,3 +408,18 @@ class TestCase(unittest.TestCase):
         keys = [x for x in d.keys_breadth_first()]
         self.assertTrue('m.m' in keys)
         self.assertEqual(len(keys), 1)
+
+    #--------------------------------------------------------------------------
+    def test_configmanize_dict(self):
+        d = {
+            "HELLO": "howdy",
+            "JELL__O": "gelatin",
+            "database_hostname": 'localhost',
+            "resources__postgres__database_hostname": 'more-localhost',
+        }
+        r = configman_keys(d)
+        self.assertTrue("HELLO" in r)
+        self.assertTrue("JELL__O" in r)
+        self.assertTrue("database_hostname" in r)
+        self.assertTrue("resources__postgres__database_hostname" not in r)
+        self.assertTrue("resources.postgres.database_hostname" in r)


### PR DESCRIPTION
It's been hard to use environment variables with nested configuration because linux shells don't allow the dot character in identifiers.  This change makes configman interpret os.environ differently.  Any doubled underscores in environment variables where the key is not all uppercase, will be interpreted as the dot character. 

"resource__postgresql__database_name" would be interpreted as "resource.postgresql.database_name".  this will make configman apps compatible with "export" as well as "env" methods  of setting environment variables.  
