### PR TITLE
replace slow list with faster ordered set

### DIFF
--- a/configman/dotdict.py
+++ b/configman/dotdict.py
@@ -40,6 +40,8 @@
 import collections
 import weakref
 
+from configman.orderedset import OrderedSet
+
 
 #------------------------------------------------------------------------------
 def iteritems_breadth_first(a_mapping, include_dicts=False):
@@ -130,7 +132,7 @@ class DotDict(collections.MutableMapping):
         parameters:
             initializer - a mapping of keys and values to be added to this
                           mapping."""
-        self.__dict__['_key_order'] = []
+        self.__dict__['_key_order'] = OrderedSet()
         if isinstance(initializer, collections.Mapping):
             for key, value in iteritems_breadth_first(
                 initializer,
@@ -146,8 +148,7 @@ class DotDict(collections.MutableMapping):
     #--------------------------------------------------------------------------
     def __setattr__(self, key, value):
         """this function saves keys into the mapping's __dict__."""
-        if key not in self._key_order:
-            self._key_order.append(key)
+        self._key_order.add(key)
         self.__dict__[key] = value
 
     #--------------------------------------------------------------------------
@@ -167,7 +168,7 @@ class DotDict(collections.MutableMapping):
     #--------------------------------------------------------------------------
     def __delattr__(self, key):
         try:
-            self._key_order.remove(key)
+            self._key_order.discard(key)
         except ValueError:
             # we must be trying to delete something that wasn't a key
             # the next line will catch the error if it still is one

--- a/configman/orderedset.py
+++ b/configman/orderedset.py
@@ -1,0 +1,81 @@
+# Copyright (C) 2009 Raymond Hettinger
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import collections
+
+class OrderedSet(collections.MutableSet):
+
+    def __init__(self, iterable=None):
+        self.end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.map = {}                   # key --> [key, prev, next]
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, next = self.map.pop(key)
+            prev[2] = next
+            next[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def pop(self, last=True):
+        if not self:
+            raise KeyError('set is empty')
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)

--- a/configman/tests/test_dotdict.py
+++ b/configman/tests/test_dotdict.py
@@ -43,6 +43,7 @@ from configman.dotdict import (
     iteritems_breadth_first,
     configman_keys
 )
+from configman.orderedset import OrderedSet
 
 
 #==============================================================================
@@ -423,3 +424,22 @@ class TestCase(unittest.TestCase):
         self.assertTrue("database_hostname" in r)
         self.assertTrue("resources__postgres__database_hostname" not in r)
         self.assertTrue("resources.postgres.database_hostname" in r)
+
+    #--------------------------------------------------------------------------
+    def test_verify_key_order(self):
+        d = DotDict()
+        d['a.b.c'] = 17
+        d['a.b.d'] = 8
+        d['a.x'] = 99
+        d['b'] = 21
+        self.assertTrue(isinstance(d._key_order, OrderedSet))
+        # the keys should be in order of insertion within each level of the
+        # nested dicts
+        keys_in_breadth_first_order = [
+            'a', 'b', 'a.b', 'a.x', 'a.b.c', 'a.b.d'
+        ]
+        self.assertEqual(
+            keys_in_breadth_first_order,
+            [k for k in d.keys_breadth_first(include_dicts=True)]
+        )
+

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -44,6 +44,7 @@ import configman.config_manager as config_manager
 import configman.datetime_util as dtu
 
 from configman.option import Option
+from configman.orderedset import OrderedSet
 
 
 #==============================================================================
@@ -274,3 +275,22 @@ class TestCase(unittest.TestCase):
         n = config_manager.Namespace()
         n.add_option(o)
         self.assertTrue(o is n.dwight)
+
+    #--------------------------------------------------------------------------
+    def test_verify_key_order(self):
+        d = config_manager.Namespace()
+        d.add_option('a.b.c')
+        d.a.b.add_option('d')
+        d.a.add_option('x')
+        d.add_aggregation('b', lambda x, y, z: None)
+        self.assertTrue(isinstance(d._key_order, OrderedSet))
+        # the keys should be in order of insertion within each level of the
+        # nested dicts
+        keys_in_breadth_first_order = [
+            'a', 'b', 'a.b', 'a.x', 'a.b.c', 'a.b.d'
+        ]
+        self.assertEqual(
+            keys_in_breadth_first_order,
+            [k for k in d.keys_breadth_first(include_dicts=True)]
+        )
+


### PR DESCRIPTION
Within Configman, DotDict and its derivatives, DotDictWithAcquisition and Namespace, are ordered dictionaries.  Until now, the order of the keys was kept in a list.  This was slow since linear search was the only way to test if a key was present.  This PR replaces that slow list with a true OrderedSet implementation. 
