### PR TITLE
added object hook for post processing value sources

### DIFF
--- a/configman/memoize.py
+++ b/configman/memoize.py
@@ -1,0 +1,37 @@
+from functools import wraps
+
+#------------------------------------------------------------------------------
+def memoize(max_cache_size=1000):
+    """Python 2.4 compatible memoize decorator.
+    It creates a cache that has a maximum size.  If the cache exceeds the max,
+    it is thrown out and a new one made.  With such behavior, it is wise to set
+    the cache just a little larger that the maximum expected need.
+
+    Parameters:
+      max_cache_size - the size to which a cache can grow
+    """
+    def wrapper(f):
+        @wraps(f)
+        def fn(*args, **kwargs):
+            if kwargs:
+                key = (args, tuple(kwargs.items()))
+            else:
+                key = args
+            try:
+                return fn.cache[key]
+            except KeyError:
+                if fn.count >= max_cache_size:
+                    fn.cache = {}
+                    fn.count = 0
+                result = f(*args, **kwargs)
+                fn.cache[key] = result
+                fn.count += 1
+                return result
+            except TypeError, x:
+                return f(*args, **kwargs)
+        fn.cache = {}
+        fn.count = 0
+        return fn
+    return wrapper
+
+

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -40,10 +40,12 @@ import dotdict
 from option import Option, Aggregation
 
 
+#==============================================================================
 class Namespace(dotdict.DotDict):
 
-    def __init__(self, doc=''):
-        super(Namespace, self).__init__()
+    #--------------------------------------------------------------------------
+    def __init__(self, doc='', initializer=None):
+        super(Namespace, self).__init__(initializer=initializer)
         object.__setattr__(self, '_doc', doc)  # force into attributes
         object.__setattr__(self, '_reference_value_from', False)
 
@@ -86,7 +88,8 @@ class Namespace(dotdict.DotDict):
 
     #--------------------------------------------------------------------------
     def namespace(self, name, doc=''):
-        setattr(self, name, Namespace(doc=doc))
+        # ensure that all new sub-namespaces are of the same type as the parent
+        setattr(self, name, self.__class__(doc=doc))
 
     #--------------------------------------------------------------------------
     def set_value(self, name, value, strict=True):

--- a/configman/tests/test_memoize.py
+++ b/configman/tests/test_memoize.py
@@ -1,0 +1,129 @@
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is configman
+#
+# The Initial Developer of the Original Code is
+# Mozilla Foundation
+# Portions created by the Initial Developer are Copyright (C) 2011
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#    K Lars Lohn, lars@mozilla.com
+#    Peter Bengtsson, peterbe@mozilla.com
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
+import unittest
+
+from configman.memoize import memoize
+
+#==============================================================================
+class TestCase(unittest.TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_memoize_function(self):
+
+        @memoize()
+        def foo(a, b, c):
+            foo.counter += 1
+            return (a, b, c)
+        foo.counter = 0
+
+        for i in range(5):
+            # repeatable and exactly 10 function calls
+            results = [foo(x, x, x) for x in range(10)]
+            expected = [(x, x, x) for x in range(10)]
+            self.assertEqual(results, expected)
+            self.assertEqual(foo.counter, 10)
+
+    #--------------------------------------------------------------------------
+    def test_memoize_instance_method(self):
+
+        class A(object):
+            def __init__(self):
+                self.counter = 0
+            @memoize()
+            def foo(self, a, b, c):
+                self.counter += 1
+                return (a, b, c)
+
+        a = A()
+        for i in range(5):
+            # repeatable and exactly 10 function calls
+            results = [a.foo(x, x, x) for x in range(10)]
+            expected = [(x, x, x) for x in range(10)]
+            self.assertEqual(results, expected)
+            self.assertEqual(a.counter, 10)
+
+        b = A()
+        # repeatable and exactly 10 function calls
+        results = [b.foo(x, x, x) for x in range(10)]
+        expected = [(x, x, x) for x in range(10)]
+        self.assertEqual(results, expected)
+        self.assertEqual(b.counter, 10)
+
+    #--------------------------------------------------------------------------
+    def test_memoize_class_method(self):
+
+        class A(object):
+            counter = 0
+
+            @classmethod
+            @memoize()
+            def foo(klass, a, b, c):
+                klass.counter += 1
+                return (a, b, c)
+
+        for i in range(5):
+            # repeatable and exactly 10 function calls
+            results = [A.foo(x, x, x) for x in range(10)]
+            expected = [(x, x, x) for x in range(10)]
+            self.assertEqual(results, expected)
+            self.assertEqual(A.counter, 10)
+
+    #--------------------------------------------------------------------------
+    def test_memoize_static_method(self):
+
+        class A(object):
+            counter = 0
+
+            @staticmethod
+            @memoize()
+            def foo(a, b, c):
+                A.counter += 1
+                return (a, b, c)
+
+        for i in range(5):
+            # repeatable and exactly 10 function calls
+            results = [A.foo(x, x, x) for x in range(10)]
+            expected = [(x, x, x) for x in range(10)]
+            self.assertEqual(results, expected)
+            self.assertEqual(A.counter, 10)
+
+
+
+
+

--- a/configman/tests/test_val_for_conf.py
+++ b/configman/tests/test_val_for_conf.py
@@ -42,9 +42,11 @@ import tempfile
 import contextlib
 from cStringIO import StringIO
 
+import configman.datetime_util as dtu
+
 from ..value_sources import for_conf
 from configman import Namespace, ConfigurationManager
-import configman.datetime_util as dtu
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 
 def stringIO_context_wrapper(a_stringIO_instance):
@@ -109,6 +111,11 @@ class TestCase(unittest.TestCase):
             # not be true for all ValueSource implementations
             self.assertEqual(o.get_values(1, False), {'limit': '20'})
             self.assertEqual(o.get_values(2, True), {'limit': '20'})
+
+            v = o.get_values(None, True, DotDict)
+            self.assertTrue(isinstance(v, DotDict))
+            v = o.get_values(None, None, obj_hook=DotDictWithAcquisition)
+            self.assertTrue(isinstance(v, DotDictWithAcquisition))
         finally:
             if os.path.isfile(tmp_filename):
                 os.remove(tmp_filename)

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -47,6 +47,7 @@ import configman.config_manager as config_manager
 
 from configman import Namespace
 from configman.config_exceptions import NotAnOptionError
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 try:
     #from ..value_sources.for_configobj import ValueSource
@@ -121,6 +122,11 @@ foo=bar  # other comment
                 self.assertEqual(o.get_values(1, True), r)
                 self.assertEqual(o.get_values(2, False), r)
                 self.assertEqual(o.get_values(3, True), r)
+
+                v = o.get_values(None, True, DotDict)
+                self.assertTrue(isinstance(v, DotDict))
+                v = o.get_values(None, None, obj_hook=DotDictWithAcquisition)
+                self.assertTrue(isinstance(v, DotDictWithAcquisition))
 
             finally:
                 if os.path.isfile(tmp_filename):

--- a/configman/tests/test_val_for_getopt.py
+++ b/configman/tests/test_val_for_getopt.py
@@ -42,6 +42,7 @@ import getopt
 import configman.config_manager as config_manager
 from configman.config_exceptions import NotAnOptionError
 from ..value_sources.for_getopt import ValueSource
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 
 #==============================================================================
@@ -71,6 +72,10 @@ class TestCase(unittest.TestCase):
         c.option_definitions.add_option('limit', default=0)
         self.assertEqual(o.get_values(c, False), {'limit': '10'})
         self.assertEqual(o.get_values(c, True), {'limit': '10'})
+        v = o.get_values(c, True, DotDict)
+        self.assertTrue(isinstance(v, DotDict))
+        v = o.get_values(c, True, DotDictWithAcquisition)
+        self.assertTrue(isinstance(v, DotDictWithAcquisition))
 
     #--------------------------------------------------------------------------
     def test_for_getopt_get_values_with_short_form(self):

--- a/configman/tests/test_val_for_json.py
+++ b/configman/tests/test_val_for_json.py
@@ -47,6 +47,7 @@ import configman.config_manager as config_manager
 import configman.datetime_util as dtu
 from ..value_sources import for_json
 from configman.value_sources.for_json import ValueSource
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 
 #------------------------------------------------------------------------------
@@ -172,3 +173,30 @@ class TestCase(unittest.TestCase):
 
         finally:
             os.unlink(name)
+
+    def test_get_values(self):
+        j = {
+            'a': '1',
+            'b': 2,
+            'c': {
+                'd': 'x',
+                'e': 'y'
+            },
+            'd': {
+                'd': 'X'
+            }
+        }
+        tmp_filename = os.path.join(tempfile.gettempdir(), 'test.json')
+        with open(tmp_filename, 'w') as f:
+            json.dump(j, f)
+        try:
+            jvs = ValueSource(tmp_filename)
+            vals = jvs.get_values(None, True, DotDict)
+            self.assertTrue(isinstance(vals, DotDict))
+            vals = jvs.get_values(None, True, DotDictWithAcquisition)
+            self.assertTrue(isinstance(vals, DotDictWithAcquisition))
+            self.assertEqual(vals.d.b, 2)
+        finally:
+            if os.path.isfile(tmp_filename):
+                os.remove(tmp_filename)
+

--- a/configman/tests/test_val_for_mapping.py
+++ b/configman/tests/test_val_for_mapping.py
@@ -40,6 +40,7 @@ import unittest
 import os
 
 from configman.value_sources.for_mapping import ValueSource
+from configman.dotdict import DotDict, DotDictWithAcquisition
 
 #==============================================================================
 class TestCase(unittest.TestCase):
@@ -75,5 +76,25 @@ class TestCase(unittest.TestCase):
         vs = ValueSource(m)
         self.assertTrue(vs.always_ignore_mismatches)
         self.assertTrue(vs.source is m)
+
+    def test_get_values(self):
+        m = {
+            'a': '1',
+            'b': 2,
+            'c': {
+                'd': 'x',
+                'e': 'y'
+            },
+            'd': {
+                'd': 'X'
+            }
+        }
+        vs = ValueSource(m)
+        v = vs.get_values(None, None)
+        self.assertTrue(isinstance(v, DotDict))
+        v = vs.get_values(None, None, obj_hook=DotDictWithAcquisition)
+        self.assertTrue(isinstance(v, DotDictWithAcquisition))
+        self.assertEqual(v.d.b, 2)
+
 
 

--- a/configman/value_sources/for_conf.py
+++ b/configman/value_sources/for_conf.py
@@ -52,6 +52,8 @@ from .. import option as opt
 from .. import converters
 
 from source_exceptions import ValueException, CantHandleTypeException
+from configman.dotdict import DotDict
+from configman.memoize import memoize
 
 function_type = type(lambda x: x)  # TODO: just how do you express the Fuction
                                    # type as a constant?
@@ -116,10 +118,13 @@ class ValueSource(object):
             )
 
     #--------------------------------------------------------------------------
-    def get_values(self, config_manager, ignore_mismatches):
+    @memoize()
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
         """the 'config_manager' and 'ignore_mismatches' are dummy values for
         this implementation of a ValueSource."""
-        return self.values
+        if isinstance(self.values, obj_hook):
+            return self.values
+        return obj_hook(initializer=self.values)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -47,6 +47,9 @@ from source_exceptions import (CantHandleTypeException, ValueException,
 from ..namespace import Namespace
 from ..option import Option
 
+from configman.dotdict import DotDict
+from configman.memoize import memoize
+
 file_name_extension = 'ini'
 
 can_handle = (
@@ -183,7 +186,8 @@ class ValueSource(object):
             raise CantHandleTypeException()
 
     #--------------------------------------------------------------------------
-    def get_values(self, config_manager, ignore_mismatches):
+    @memoize()
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
         """Return a nested dictionary representing the values in the ini file.
         In the case of this ValueSource implementation, both parameters are
         dummies."""
@@ -196,8 +200,10 @@ class ValueSource(object):
             except AttributeError:
                 # we don't have enough information to get the ini file
                 # yet.  we'll ignore the error for now
-                return {}
-        return self.config_obj
+                return obj_hook()  # return empty dict of the obj_hook type
+        if isinstance(self.config_obj, obj_hook):
+            return self.config_obj
+        return obj_hook(initializer=self.config_obj)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -47,6 +47,9 @@ from ..option import Option, Aggregation
 from source_exceptions import (ValueException, NotEnoughInformationException,
                                CantHandleTypeException)
 
+from configman.dotdict import DotDict
+from configman.memoize import memoize
+
 can_handle = (
     basestring,
     json
@@ -95,8 +98,11 @@ class ValueSource(object):
             raise CantHandleTypeException()
 
     #--------------------------------------------------------------------------
-    def get_values(self, config_manager, ignore_mismatches):
-        return self.values
+    @memoize()
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
+        if isinstance(self.values, obj_hook):
+            return self.values
+        return obj_hook(self.values)
 
     #--------------------------------------------------------------------------
     @staticmethod

--- a/configman/value_sources/for_mapping.py
+++ b/configman/value_sources/for_mapping.py
@@ -41,6 +41,10 @@ import os
 
 from source_exceptions import CantHandleTypeException
 
+from configman.dotdict import DotDict
+from configman.memoize import memoize
+
+
 can_handle = (
     os.environ,
     collections.Mapping,
@@ -64,5 +68,9 @@ class ValueSource(object):
         self.source = source
 
     #--------------------------------------------------------------------------
-    def get_values(self, config_manager, ignore_mismatches):
-        return self.source
+    @memoize()
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
+        if isinstance(self.source, obj_hook):
+            return self.source
+        return obj_hook(initializer=self.source)
+


### PR DESCRIPTION
don't be intimidated by the size, most of the changes are adding tests

When a value source (mappings from the commandline, config file, environment, etc) is brought into configman, they've been translated into instance of DotDict.  This change adds an `object_hook` so that the translation can be into whatever Mapping type is useful.  

The first application for this will be to support legacy keys in existing configurations for crontabber.  That app, unfortunately, used the hyphen in namespace names.  Hyphens are not allowed in environment variables.  Crontabber will be modified to not define requirements with hyphens.  However, we still want existing config files that use hyphens to still be useful.  This will be done by having crontabber use a DotDict variant that translates keys with hyphens into keys with underscores.  That mapping class will be used as `value_source_object_hook`.  For crontabber, the  hyphen and underscore will be treated as if they were underscores.  

I hesitated to bake this key translation directly into configman.  I didn't want the overhead, nor did I want to force clients of configman into restrictive key rules.  Armed with this new system using an object hook, crontabber will be able to use a translating  system and other clients of configman won't suffer the overhead of the translations.
