### PR TITLE
Fix typo causing `python setup.py test` to fail.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=['configman'],
     package_data={'configman': ['*/*', 'version.txt']},
     install_requires=find_install_requires(),
-    tests_required=find_tests_require(),
+    tests_require=find_tests_require(),
     test_suite='nose.collector',
     zip_safe=False,
 ),


### PR DESCRIPTION
setuptools takes an argument `tests_require` that lists packages
required for tests to run. This was typoed in the past tense as
`tests_required`.
