### PR TITLE
an incremental step toward better converters

### DIFF
--- a/configman/converters.py
+++ b/configman/converters.py
@@ -40,7 +40,6 @@ import sys
 import re
 import datetime
 import types
-import inspect
 import json
 
 from required_config import RequiredConfig
@@ -51,6 +50,12 @@ from .datetime_util import date_from_ISO_string as date_converter
 from .config_exceptions import CannotConvertError
 
 import datetime_util
+
+#------------------------------------------------------------------------------
+#  Utility section
+#
+#  various handy functions used or associated with type conversions
+#------------------------------------------------------------------------------
 
 
 #------------------------------------------------------------------------------
@@ -97,68 +102,68 @@ def str_dict_keys(a_dict):
 
 
 #------------------------------------------------------------------------------
-def io_converter(input_str):
-    """ a conversion function for to select stdout, stderr or open a file for
-    writing"""
-    if type(input_str) is str:
-        input_str_lower = input_str.lower()
-        if input_str_lower == 'stdout':
-            return sys.stdout
-        if input_str_lower == 'stderr':
-            return sys.stderr
-        return open(input_str, "w")
+def str_quote_stripper(input_str):
+    if not isinstance(input_str, basestring):
+        raise ValueError(input_str)
+    while (
+        input_str
+        and input_str[0] == input_str[-1]
+        and input_str[0] in ("'", '"')
+    ):
+        input_str = input_str.strip(input_str[0])
     return input_str
 
 
 #------------------------------------------------------------------------------
-def timedelta_converter(input_str):
-    """a conversion function for time deltas"""
-    if isinstance(input_str, basestring):
-        days, hours, minutes, seconds = 0, 0, 0, 0
-        details = input_str.split(':')
-        if len(details) >= 4:
-            days = int(details[-4])
-        if len(details) >= 3:
-            hours = int(details[-3])
-        if len(details) >= 2:
-            minutes = int(details[-2])
-        if len(details) >= 1:
-            seconds = int(details[-1])
-        return datetime.timedelta(
-            days=days,
-            hours=hours,
-            minutes=minutes,
-            seconds=seconds
-        )
-    raise ValueError(input_str)
+#  from string section
+#
+#  a set of functions that will convert from a string representation into some
+#  specified type
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+# a bunch of known mappings of builtin items to strings
+import __builtin__
+known_mapping_str_to_type = dict(
+    (key, val) for key, val in __builtin__.__dict__.iteritems()
+    if val not in (True, False)
+)
+
+#------------------------------------------------------------------------------
+from configman.datetime_util import (
+    str_to_timedelta,  # don't worry about pyflakes here, unused in this file
+    timedelta_to_str,  # but used elsewhere
+)
+
+timedelta_converter = str_to_timedelta  # for backward compatiblity
 
 
 #------------------------------------------------------------------------------
-def boolean_converter(input_str):
+def str_to_boolean(input_str):
     """ a conversion function for boolean
     """
+    if not isinstance(input_str, basestring):
+        raise ValueError(input_str)
+    input_str = str_quote_stripper(input_str)
     return input_str.lower() in ("true", "t", "1", "y", "yes")
 
-
-#------------------------------------------------------------------------------
-def list_converter(input_str):
-    """ a conversion function for list
-    """
-    return [x.strip() for x in input_str.split(',') if x.strip()]
+boolean_converter = str_to_boolean  # for backward compatiblity
 
 
 #------------------------------------------------------------------------------
-import __builtin__
-_all_named_builtins = dir(__builtin__)
-
-
-def class_converter(input_str):
+def str_to_python_object(input_str):
     """ a conversion that will import a module and class name
     """
     if not input_str:
         return None
-    if '.' not in input_str and input_str in _all_named_builtins:
-        return eval(input_str)
+    if not isinstance(input_str, basestring):
+        # gosh, we didn't get a string, we can't convert anything but strings
+        # we're going to assume that what we got is actually what was wanted
+        # as the output
+        return input_str
+    input_str = str_quote_stripper(input_str)
+    if '.' not in input_str and input_str in known_mapping_str_to_type:
+        return known_mapping_str_to_type[input_str]
     parts = [x.strip() for x in input_str.split('.') if x.strip()]
     try:
         try:
@@ -176,10 +181,14 @@ def class_converter(input_str):
         return obj
     except AttributeError, x:
         raise CannotConvertError("%s cannot be found" % input_str)
+    except ImportError, x:
+        raise CannotConvertError(str(x))
+
+class_converter = str_to_python_object  # for backward compatibility
 
 
 #------------------------------------------------------------------------------
-def classes_in_namespaces_converter(
+def str_to_classes_in_namespaces(
     template_for_namespace="cls%d",
     name_of_class_option='cls',
     instantiate_classes=False
@@ -299,15 +308,50 @@ def classes_in_namespaces_converter(
         return InnerClassList  # result of class_list_converter
     return class_list_converter  # result of classes_in_namespaces_converter
 
+# for backward compatibility
+classes_in_namespaces_converter = str_to_classes_in_namespaces
+
 
 #------------------------------------------------------------------------------
-def regex_converter(input_str):
+def str_to_regular_expression(input_str):
     return re.compile(input_str)
+
+regex_converter = str_to_regular_expression  # for backward compatibility
 
 compiled_regexp_type = type(re.compile(r'x'))
 
+
 #------------------------------------------------------------------------------
-from_string_converters = {
+def str_to_list(
+    input_str,
+    item_converter=lambda x: x,
+    item_separator=',',
+    list_to_collection_converter=None
+):
+    """ a conversion function for list
+    """
+    if not isinstance(input_str, basestring):
+        raise ValueError(input_str)
+    input_str = str_quote_stripper(input_str)
+    result = [
+        item_converter(x.strip())
+        for x in input_str.split(item_separator) if x.strip()
+    ]
+    if list_to_collection_converter is not None:
+        return list_to_collection_converter(result)
+    return result
+
+list_converter = str_to_list  # for backward compatibility
+
+
+#------------------------------------------------------------------------------
+#
+#   To string section
+#
+#------------------------------------------------------------------------------
+
+#------------------------------------------------------------------------------
+str_to_instance_of_type_converters = {
     int: int,
     float: float,
     str: str,
@@ -323,27 +367,79 @@ from_string_converters = {
     compiled_regexp_type: regex_converter,
 }
 
+ # backward compatibility
+from_string_converters = str_to_instance_of_type_converters
+
 
 #------------------------------------------------------------------------------
-def py_obj_to_str(a_thing):
+def arbitrary_object_to_string(a_thing):
+    """take a python object of some sort, and convert it into a human readable
+    string.  this function is used extensively to convert things like "subject"
+    into "subject_key, function -> function_key, etc."""
+    # is it None?
     if a_thing is None:
         return ''
+    # is it already a string?
     if isinstance(a_thing, basestring):
         return a_thing
-    if inspect.ismodule(a_thing):
-        return a_thing.__name__
-    if a_thing.__module__ == '__builtin__':
-        return a_thing.__name__
-    if a_thing.__module__ == "__main__":
-        return a_thing.__name__
-    if hasattr(a_thing, 'to_str'):
+    # does it have a to_str function?
+    try:
         return a_thing.to_str()
-    return "%s.%s" % (a_thing.__module__, a_thing.__name__)
+    except (AttributeError, KeyError, TypeError):
+        # AttributeError - no to_str function?
+        # KeyError - DotDict has no to_str?
+        # TypeError - problem converting
+        # nope, no to_str function
+        pass
+    # is this a type proxy?
+    try:
+        return arbitrary_object_to_string(a_thing.a_type)
+    except (AttributeError, KeyError, TypeError):
+        #
+        # nope, no a_type property
+        pass
+    # is it a built in?
+    try:
+        return known_mapping_type_to_str[a_thing]
+    except (KeyError, TypeError):
+        # nope, not a builtin
+        pass
+    # is it something from a loaded module?
+    try:
+        if a_thing.__module__ not in ('__builtin__', 'exceptions'):
+            if a_thing.__module__ == "__main__":
+                module_name = \
+                    sys.modules['__main__'].__file__[:-3].replace('/', '.')
+                while module_name.startswith('.'):  # remove leading '.'
+                    module_name = module_name[1:]
+            else:
+                module_name = a_thing.__module__
+            return "%s.%s" % (module_name, a_thing.__name__)
+    except AttributeError:
+        # nope, not one of these
+        pass
+    # maybe it has a __name__ attribute?
+    try:
+        return a_thing.__name__
+    except AttributeError:
+        # nope, not one of these
+        pass
+    # punt and see what happens if we just cast it to string
+    return str(a_thing)
+
+
+py_obj_to_str = arbitrary_object_to_string  # for backwards compatibility
 
 
 #------------------------------------------------------------------------------
 def list_to_str(a_list):
-    return ', '.join(to_string_converters[type(x)](x) for x in a_list)
+    return ', '.join(to_str(x) for x in a_list)
+
+#------------------------------------------------------------------------------
+known_mapping_type_to_str = dict(
+    (val, key) for key, val in __builtin__.__dict__.iteritems()
+    if val not in (True, False, list, dict)
+)
 
 #------------------------------------------------------------------------------
 to_string_converters = {
@@ -358,12 +454,19 @@ to_string_converters = {
     datetime.datetime: datetime_util.datetime_to_ISO_string,
     datetime.date: datetime_util.date_to_ISO_string,
     datetime.timedelta: datetime_util.timedelta_to_str,
-    type: py_obj_to_str,
-    types.ModuleType: py_obj_to_str,
-    types.FunctionType: py_obj_to_str,
+    type: arbitrary_object_to_string,
+    types.ModuleType: arbitrary_object_to_string,
+    types.FunctionType: arbitrary_object_to_string,
     compiled_regexp_type: lambda x: x.pattern,
 }
 
+
+#------------------------------------------------------------------------------
+def to_str(a_thing):
+    try:
+        return to_string_converters[type(a_thing)](a_thing)
+    except KeyError:
+        return arbitrary_object_to_string(a_thing)
 
 #------------------------------------------------------------------------------
 converters_requiring_quotes = [eval, regex_converter]

--- a/configman/datetime_util.py
+++ b/configman/datetime_util.py
@@ -81,8 +81,13 @@ def timedelta_to_seconds(td):
 
 def str_to_timedelta(input_str):
     """ a string conversion function for timedelta for strings in the format
-    DD:HH:MM:SS
+    DD:HH:MM:SS or D HH:MM:SS
     """
+    try:
+        input_str = input_str.replace(' ', ':')
+    except (TypeError, AttributeError):
+        from configman.converters import to_str
+        raise TypeError('%s should have been a string' % to_str(input_str))
     days, hours, minutes, seconds = 0, 0, 0, 0
     details = input_str.split(':')
     if len(details) >= 4:
@@ -108,4 +113,4 @@ def timedelta_to_str(aTimedelta):
     hours = temp_seconds / 3600
     minutes = (temp_seconds - hours * 3600) / 60
     seconds = temp_seconds - hours * 3600 - minutes * 60
-    return '%d:%d:%d:%d' % (days, hours, minutes, seconds)
+    return '%d %02d:%02d:%02d' % (days, hours, minutes, seconds)

--- a/configman/option.py
+++ b/configman/option.py
@@ -93,22 +93,10 @@ class Option(object):
         All it requires is that the passed option instance has a ``value``
         attribute.
         """
-        if self.value is None:
-            return ''
-        if self.to_string_converter:
-            s = self.to_string_converter(self.value)
-        else:
-            try:
-                converter = conv.to_string_converters[type(self.value)]
-                s = converter(self.value)
-            except KeyError:
-                if not isinstance(self.value, basestring):
-                    s = unicode(self.value)
-                else:
-                    s = self.value
-        if self.from_string_converter in conv.converters_requiring_quotes:
-            s = "'''%s'''" % s
-        return s
+        try:
+            return self.to_string_converter(self.value)
+        except TypeError:
+            return conv.to_str(self.value)
 
     #--------------------------------------------------------------------------
     def __eq__(self, other):
@@ -135,7 +123,11 @@ class Option(object):
     #--------------------------------------------------------------------------
     def _deduce_converter(self, default):
         default_type = type(default)
-        return conv.from_string_converters.get(default_type, default_type)
+
+        return conv.str_to_instance_of_type_converters.get(
+            default_type,
+            default_type
+        )
 
     #--------------------------------------------------------------------------
     def set_value(self, val=None):

--- a/configman/tests/test_converters.py
+++ b/configman/tests/test_converters.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ***** BEGIN LICENSE BLOCK *****
 # Version: MPL 1.1/GPL 2.0/LGPL 2.1
 #
@@ -38,8 +39,11 @@
 
 import unittest
 import tempfile
+import datetime
+
 from configman import converters
 from configman import RequiredConfig, Namespace, ConfigurationManager
+from configman.dotdict import DotDict
 
 
 #==============================================================================
@@ -70,6 +74,35 @@ class Alpha(RequiredConfig):
     def __init__(self, config):
         self.config = config
         self.a = config.a
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        return "I am an instance of an Alpha object"
+
+
+#==============================================================================
+class AlphaBad1(Alpha):
+    def __init__(self, config):
+        super(AlphaBad1, self).__init__(config)
+        self.a_type = int
+
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise AttributeError
+
+
+#==============================================================================
+class AlphaBad2(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise KeyError
+
+
+#==============================================================================
+class AlphaBad3(AlphaBad1):
+    #--------------------------------------------------------------------------
+    def to_str(self):
+        raise TypeError
 
 
 #==============================================================================
@@ -104,50 +137,64 @@ class TestCase(unittest.TestCase):
                 self.assertTrue(isinstance(key, int))
 
     #--------------------------------------------------------------------------
-    def test_io_converter(self):
-        function = converters.io_converter
-        import sys
-        import os
-        self.assertEqual(function(100.0), 100.0)
-        self.assertEqual(function('stdout'), sys.stdout)
-        self.assertEqual(function('STDOut'), sys.stdout)
-        self.assertEqual(function('Stderr'), sys.stderr)
-        tmp_filename = os.path.join(tempfile.gettempdir(), 'test.anything')
-        try:
-            r = function(tmp_filename)
-            self.assertTrue(hasattr(r, 'write'))
-            self.assertTrue(hasattr(r, 'close'))
-            r.write('stuff\n')
-            r.close()
-            self.assertEqual(open(tmp_filename).read(), 'stuff\n')
-        finally:
-            if os.path.isfile(tmp_filename):
-                os.remove(tmp_filename)
+    def test_str_quote_stripper(self):
+        a = """'"single and double quoted"'"""
+        self.assertEqual(
+            converters.str_quote_stripper(a),
+            'single and double quoted'
+        )
+
+        a = """'single quoted'"""
+        self.assertEqual(converters.str_quote_stripper(a), 'single quoted')
+
+        a = '''"double quoted"'''
+        self.assertEqual(converters.str_quote_stripper(a), 'double quoted')
+
+        a = '"""triple quoted"""'
+        self.assertEqual(converters.str_quote_stripper(a), 'triple quoted')
+
+        a = "'''triple quoted'''"
+        self.assertEqual(converters.str_quote_stripper(a), 'triple quoted')
+
+        a = '''"trailing apostrophy'"'''
+        self.assertEqual(
+            converters.str_quote_stripper(a),
+            "trailing apostrophy'"
+        )
 
     #--------------------------------------------------------------------------
-    def test_timedelta_converter(self):
-        function = converters.timedelta_converter
+    def test_str_to_timedelta(self):
+        str_to_timedelta = converters.timedelta_converter
         from datetime import timedelta
-        self.assertEqual(function('1'), timedelta(seconds=1))
-        self.assertEqual(function('2:1'), timedelta(minutes=2, seconds=1))
         self.assertEqual(
-            function('3:2:1'),
+            str_to_timedelta('1'),
+            timedelta(seconds=1)
+        )
+        self.assertEqual(
+            str_to_timedelta('2:1'),
+            timedelta(minutes=2, seconds=1)
+        )
+        self.assertEqual(
+            str_to_timedelta('3:2:1'),
             timedelta(hours=3, minutes=2, seconds=1)
         )
         self.assertEqual(
-            function('4:3:2:1'),
+            str_to_timedelta('4:3:2:1'),
             timedelta(days=4, hours=3, minutes=2, seconds=1)
         )
-        self.assertRaises(ValueError, function, 'xxx')
-        self.assertRaises(ValueError, function, 10.1)
+        self.assertEqual(
+            str_to_timedelta('4 03:02:01'),
+            timedelta(days=4, hours=3, minutes=2, seconds=1)
+        )
+        self.assertRaises(ValueError, str_to_timedelta, 'xxx')
+        self.assertRaises(TypeError, str_to_timedelta, 10.1)
 
     #--------------------------------------------------------------------------
-    def test_class_converter_nothing(self):
-        function = converters.class_converter
-        self.assertEqual(function(''), None)
+    def test_str_to_python_object_nothing(self):
+        self.assertEqual(converters.str_to_python_object(''), None)
 
     #--------------------------------------------------------------------------
-    def test_class_converter_with_whitespace(self):
+    def test_str_to_python_object_with_whitespace(self):
         """either side whitespace doesn't matter"""
         function = converters.class_converter
         self.assertEqual(
@@ -157,64 +204,6 @@ class TestCase(unittest.TestCase):
 
         """),
             Foo)
-
-    #--------------------------------------------------------------------------
-    def test_py_obj_to_str(self):
-        function = converters.py_obj_to_str
-        self.assertEqual(function(None), '')
-        from configman import tests as tests_module
-        self.assertEqual(function(tests_module), 'configman.tests')
-        self.assertEqual(function(int), 'int')
-
-    #--------------------------------------------------------------------------
-    def test_str_to_list(self):
-        function = converters.list_converter
-        self.assertEqual(function(''), [])
-
-        self.assertEqual(
-            function('configman.tests.test_converters.TestCase'),
-            ['configman.tests.test_converters.TestCase']
-        )
-        self.assertEqual(
-            function('configman.tests, configman'),
-            ['configman.tests', 'configman']
-        )
-        self.assertEqual(
-            function('int, str, 123, hello'),
-            ['int', 'str', '123', 'hello']
-        )
-
-    #--------------------------------------------------------------------------
-    def test_list_to_str(self):
-        function = converters.list_to_str
-        self.assertEqual(function([]), '')
-        self.assertEqual(function(tuple()), '')
-
-        import configman
-        self.assertEqual(
-            function([configman.tests.test_converters.TestCase]),
-            'configman.tests.test_converters.TestCase'
-        )
-        self.assertEqual(
-            function([configman.tests, configman]),
-            'configman.tests, configman'
-        )
-        self.assertEqual(
-            function([int, str, 123, "hello"]),
-            'int, str, 123, hello'
-        )
-        self.assertEqual(
-            function((configman.tests.test_converters.TestCase,)),
-            'configman.tests.test_converters.TestCase'
-        )
-        self.assertEqual(
-            function((configman.tests, configman)),
-            'configman.tests, configman'
-        )
-        self.assertEqual(
-            function((int, str, 123, "hello")),
-            'int, str, 123, hello'
-        )
 
     #--------------------------------------------------------------------------
     def test_dict_conversions(self):
@@ -227,7 +216,7 @@ class TestCase(unittest.TestCase):
         s = converter_fn(d)
 
         # round  trip
-        converter_fn = converters.from_string_converters[type(d)]
+        converter_fn = converters.str_to_instance_of_type_converters[type(d)]
         dd = converter_fn(s)
         self.assertEqual(dd, d)
 
@@ -323,3 +312,215 @@ class TestCase(unittest.TestCase):
                 isinstance(config[x].kls_instance,
                            config[x].kls)
             )
+
+    #--------------------------------------------------------------------------
+    def test_to_str_to_regular_expression(self):
+        import re
+        self.assertEqual(
+            converters.str_to_regular_expression('.*'),
+            re.compile('.*')
+        )
+
+    #--------------------------------------------------------------------------
+    def test_str_to_list(self):
+        function = converters.list_converter
+        self.assertEqual(function(''), [])
+
+        self.assertEqual(
+            function('configman.tests.test_converters.TestCase'),
+            ['configman.tests.test_converters.TestCase']
+        )
+        self.assertEqual(
+            function('configman.tests, configman'),
+            ['configman.tests', 'configman']
+        )
+        self.assertEqual(
+            function('int, str, 123, hello'),
+            ['int', 'str', '123', 'hello']
+        )
+        self.assertEqual(
+            function(u'P\xefter, L\xa3rs'),
+            [u'P\xefter', u'L\xa3rs']
+        )
+    #--------------------------------------------------------------------------
+    def test_to_str(self):
+        to_str = converters.to_str
+        self.assertEqual(to_str(int), 'int')
+        self.assertEqual(to_str(float), 'float')
+        self.assertEqual(to_str(str), 'str')
+        self.assertEqual(to_str(unicode), 'unicode')
+        self.assertEqual(to_str(bool), 'bool')
+        self.assertEqual(to_str(dict), 'dict')
+        self.assertEqual(to_str(list), 'list')
+        self.assertEqual(to_str(datetime.datetime), 'datetime.datetime')
+        self.assertEqual(to_str(datetime.date), 'datetime.date')
+        self.assertEqual(to_str(datetime.timedelta), 'datetime.timedelta')
+        self.assertEqual(to_str(type), 'type')
+        self.assertEqual(
+            to_str(converters.compiled_regexp_type),
+            '_sre.SRE_Pattern'
+        )
+        self.assertEqual(to_str(1), '1')
+        self.assertEqual(to_str(3.1415), '3.1415')
+        self.assertEqual(
+            to_str(datetime.datetime(
+                1960,
+                5,
+                4,
+                15,
+                10
+            )),
+            '1960-05-04T15:10:00'
+        )
+        self.assertEqual(to_str(True), 'True')
+        self.assertEqual(to_str(False), 'False')
+        self.assertEqual(to_str((2, False, int, max)), '2, False, int, max')
+        self.assertEqual(to_str(None), '')
+
+    #--------------------------------------------------------------------------
+    def test_str_to_boolean(self):
+        self.assertTrue(converters.str_to_boolean('TRUE'))
+        self.assertTrue(converters.str_to_boolean('"""TRUE"""'))
+        self.assertTrue(converters.str_to_boolean('true'))
+        self.assertTrue(converters.str_to_boolean('t'))
+        self.assertTrue(converters.str_to_boolean('1'))
+        self.assertTrue(converters.str_to_boolean('T'))
+        self.assertTrue(converters.str_to_boolean('yes'))
+        self.assertTrue(converters.str_to_boolean("'yes'"))
+        self.assertTrue(converters.str_to_boolean('y'))
+
+        self.assertFalse(converters.str_to_boolean('FALSE'))
+        self.assertFalse(converters.str_to_boolean('false'))
+        self.assertFalse(converters.str_to_boolean('f'))
+        self.assertFalse(converters.str_to_boolean('F'))
+        self.assertFalse(converters.str_to_boolean('no'))
+        self.assertFalse(converters.str_to_boolean('NO'))
+        self.assertFalse(converters.str_to_boolean(''))
+        self.assertFalse(converters.str_to_boolean(
+            '你好, says Lärs'
+        ))
+        self.assertRaises(ValueError, converters.str_to_boolean, 99)
+
+    #--------------------------------------------------------------------------
+    def test_arbitrary_object_to_string(self):
+        function = converters.py_obj_to_str
+        self.assertEqual(function(None), '')
+        self.assertEqual(function('hello'), 'hello')
+
+        config = DotDict()
+        config.a = 17
+        config.b = 23
+        a = Alpha(config)
+        self.assertEqual(
+            converters.arbitrary_object_to_string(a),
+            "I am an instance of an Alpha object"
+        )
+        a = AlphaBad1(config)
+        self.assertEqual(
+            converters.arbitrary_object_to_string(a),
+            "int"
+        )
+        a = AlphaBad2(config)
+        self.assertEqual(
+            converters.arbitrary_object_to_string(a),
+            "int"
+        )
+        a = AlphaBad3(config)
+        self.assertEqual(
+            converters.arbitrary_object_to_string(a),
+            "int"
+        )
+        self.assertEqual(
+            converters.arbitrary_object_to_string(IndexError),
+            "IndexError"
+        )
+
+        self.assertEqual(
+            converters.arbitrary_object_to_string(Beta),
+            "configman.tests.test_converters.Beta"
+        )
+
+        from configman import tests as tests_module
+        self.assertEqual(function(tests_module), 'configman.tests')
+
+    #--------------------------------------------------------------------------
+    def test_list_to_str(self):
+        function = converters.list_to_str
+        self.assertEqual(function([]), '')
+        self.assertEqual(function(tuple()), '')
+
+        import configman
+        self.assertEqual(
+            function([configman.tests.test_converters.TestCase]),
+            'configman.tests.test_converters.TestCase'
+        )
+        self.assertEqual(
+            function([configman.tests, configman]),
+            'configman.tests, configman'
+        )
+        self.assertEqual(
+            function([int, str, 123, "hello"]),
+            'int, str, 123, hello'
+        )
+        self.assertEqual(
+            function((configman.tests.test_converters.TestCase,)),
+            'configman.tests.test_converters.TestCase'
+        )
+        self.assertEqual(
+            function((configman.tests, configman)),
+            'configman.tests, configman'
+        )
+        self.assertEqual(
+            function((int, str, 123, "hello")),
+            'int, str, 123, hello'
+        )
+        self.assertEqual(
+            function((u'P\xefter', u'L\xa3rs')),
+            u'P\xefter, L\xa3rs'
+        )
+
+    #--------------------------------------------------------------------------
+    def test_to_str(self):
+        self.assertEqual(converters.to_str(1), "1")
+        self.assertEqual(converters.to_str(3.1415), "3.1415")
+        self.assertEqual(converters.to_str('hello'), "hello")
+        self.assertEqual(
+            converters.to_str(u"'你好'"),
+            u"'\u4f60\u597d'"
+        )
+        self.assertEqual(
+            converters.list_to_str([1, 2, 3]),
+            "1, 2, 3"
+        )
+        self.assertEqual(
+            converters.to_str(True),
+            "True"
+        )
+        self.assertEqual(
+            converters.to_str(False),
+            "False"
+        )
+        self.assertEqual(
+            converters.to_str(datetime.datetime(1960, 5, 4, 15, 10)),
+            "1960-05-04T15:10:00"
+        )
+        self.assertEqual(
+            converters.to_str(datetime.date(1960, 5, 4)),
+            "1960-05-04"
+        )
+        self.assertEqual(
+            converters.to_str(datetime.timedelta(days=1, seconds=1)),
+            "1 00:00:01"
+        )
+        self.assertEqual(converters.to_str(int), 'int')
+        self.assertEqual(converters.to_str(float), 'float')
+        self.assertEqual(converters.to_str(unittest), 'unittest')
+
+        self.assertEqual(
+            converters.to_str(converters.to_str),
+            'configman.converters.to_str'
+        )
+
+        import re
+        r = re.compile('.*')
+        self.assertEqual(converters.to_str(r), '.*')

--- a/configman/tests/test_datetime_util.py
+++ b/configman/tests/test_datetime_util.py
@@ -133,6 +133,30 @@ class TestCase(unittest.TestCase):
             )
         )
         self.assertEqual(
+            function('2 00:00:00'),
+            datetime.timedelta(
+                days=2,
+            )
+        )
+        self.assertEqual(
+            function('01:01:01:01'),
+            datetime.timedelta(
+                days=1,
+                hours=1,
+                minutes=1,
+                seconds=1
+            )
+        )
+        self.assertEqual(
+            function('1:1:1:01'),
+            datetime.timedelta(
+                days=1,
+                hours=1,
+                minutes=1,
+                seconds=1
+            )
+        )
+        self.assertEqual(
             function('1:1:1'),
             datetime.timedelta(
                 hours=1,
@@ -152,3 +176,8 @@ class TestCase(unittest.TestCase):
             datetime.timedelta(seconds=1)
         )
         self.assertRaises(ValueError, function, 'not a number')
+        self.assertEqual(
+            function('1'),
+            datetime.timedelta(seconds=1)
+        )
+        self.assertRaises(TypeError, function, 10.1)

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -114,7 +114,6 @@ class TestCase(unittest.TestCase):
         self.assertEqual(o.default, '1')
         self.assertEqual(o.value, 1)
 
-
         data = {
             'name': 'lucy',
             'default': '1',
@@ -182,7 +181,7 @@ class TestCase(unittest.TestCase):
         data = {
             'default': '2011-12-31',
             'doc': "lucy's bday",
-            'from_string_converter': \
+            'from_string_converter':
             'configman.datetime_util.date_from_ISO_string',
         }
         o = Option('now', **data)
@@ -387,8 +386,8 @@ class TestCase(unittest.TestCase):
     #--------------------------------------------------------------------------
     def test_set_default(self):
         o1 = Option(
-          'name',
-          default=23
+            'name',
+            default=23
         )
         self.assertEqual(o1.value, 23)
         self.assertRaises(OptionError, o1.set_default, 68)
@@ -397,8 +396,8 @@ class TestCase(unittest.TestCase):
         self.assertTrue(o1.default, 68)
 
         o2 = Option(
-          'name',
-          default=None
+            'name',
+            default=None
         )
         self.assertTrue(o2.value is None)
         o2.set_default(68)

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -215,12 +215,12 @@ bad_option=bar  # other comment
                 argv_source=[]
             )
             expected = """# the a
-#aaa='2011-05-04T15:10:00'
+#aaa=2011-05-04T15:10:00
 
 [c]
 
     # husband from Flintstones
-    #fred='stupid, deadly'
+    #fred=stupid, deadly
 
     # wife from Flintstones
     #wilma=waspish's
@@ -282,7 +282,7 @@ bad_option=bar  # other comment
                 argv_source=[]
             )
             expected = ("""# the a
-#aaa='2011-05-04T15:10:00'
+#aaa=2011-05-04T15:10:00
 
 [xxx]
 
@@ -298,7 +298,7 @@ bad_option=bar  # other comment
 [c]
 
     # husband from Flintstones
-    #fred='stupid, deadly'
+    #fred=stupid, deadly
 
     # wife from Flintstones
     #wilma=waspish's
@@ -360,7 +360,7 @@ bad_option=bar  # other comment
                 use_auto_help=False,
                 argv_source=[]
             )
-            expected = "# the doc string\n#a='one:One'\n"
+            expected = "# the doc string\n#a=one:One\n"
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))
             received = out.getvalue()

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -252,16 +252,6 @@ class ValueSource(object):
             else:
                 option_format = '%s#%s=%s\n'
 
-            repr_for_converter = repr(an_option.from_string_converter)
-            if (
-                repr_for_converter.startswith('<function') or
-                repr_for_converter.startswith('<built-in')
-            ):
-                option_value = repr(option_value)
-            elif an_option.from_string_converter is str:
-                if ',' in option_value or '\n' in option_value:
-                    option_value = repr(option_value)
-
             print >>output_stream, option_format % (
                 indent_spacer,
                 an_option.name,


### PR DESCRIPTION
this is a step toward a better converter system for configman.  The immediate benefit to this change is that the excessive quoting done by the ini handler is gone and paths to classes are completely qualified.

Some redundancy has been eliminated (there was more than one timedelta converter), and the converter section has been arranged into three sections: utility, from string and to string
