### PR TITLE
extended mapping_class for config to function & context

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -69,11 +69,10 @@ def configuration(*args, **kwargs):
     """this function just instantiates a ConfigurationManager and returns
     the configuration dictionary.  It accepts all the same parameters as the
     constructor for the ConfigurationManager class."""
-    if 'mapping_class' in kwargs:
-        mapping_class = kwargs.pop('mapping_class')
-    cm = ConfigurationManager(*args, **kwargs)
     try:
-        return cm.get_config(mapping_class=mapping_class)
-    except NameError:
-        return cm.get_config()
+        config_kwargs = {'mapping_class': kwargs.pop('mapping_class')}
+    except KeyError:
+        config_kwargs = {}
+    cm = ConfigurationManager(*args, **kwargs)
+    return cm.get_config(**config_kwargs)
 

--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -69,5 +69,11 @@ def configuration(*args, **kwargs):
     """this function just instantiates a ConfigurationManager and returns
     the configuration dictionary.  It accepts all the same parameters as the
     constructor for the ConfigurationManager class."""
+    if 'mapping_class' in kwargs:
+        mapping_class = kwargs.pop('mapping_class')
     cm = ConfigurationManager(*args, **kwargs)
-    return cm.get_config()
+    try:
+        return cm.get_config(mapping_class=mapping_class)
+    except NameError:
+        return cm.get_config()
+

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -271,12 +271,12 @@ class ConfigurationManager(object):
 
     #--------------------------------------------------------------------------
     @contextlib.contextmanager
-    def context(self):
+    def context(self, mapping_class=DotDictWithAcquisition):
         """return a config as a context that calls close on every item when
         it goes out of scope"""
         config = None
         try:
-            config = self.get_config()
+            config = self.get_config(mapping_class=mapping_class)
             yield config
         finally:
             if config:


### PR DESCRIPTION
the method `ConfigurationManager.get_config` accepts an object hook so that the users can specify what type of mapping container in which they want their configuration.  That method isn't the only way to get configuration out of configman.  

This PR extends the mapping object_hook to the two other ways to get configuration:  `ConfigurationManager.context` and the bare function `configuration`
