### PR TITLE
add the ability for modules to be used as value/overlay sources

### DIFF
--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -1942,13 +1942,14 @@ c.string =   from ini
         n = self._common_app_namespace_setup()
 
         # make a config file that nothing will understand
-        open('x.fred', 'w').write(
-            '[toplevel]\n'
-            'password=something\n'
-        )
+        with open('x.fred', 'w') as f:
+            f.write(
+                '[toplevel]\n'
+                'password=something\n'
+            )
         try:
             self.assertRaises(
-                NoHandlerForType,
+                AllHandlersFailedException,
                 config_manager.ConfigurationManager,
                 (n,),
                 argv_source=['--admin.conf=x.fred']

--- a/configman/tests/test_val_for_modules.py
+++ b/configman/tests/test_val_for_modules.py
@@ -1,0 +1,524 @@
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is configman
+#
+# The Initial Developer of the Original Code is
+# Mozilla Foundation
+# Portions created by the Initial Developer are Copyright (C) 2011
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#    K Lars Lohn, lars@mozilla.com
+#    Peter Bengtsson, peterbe@mozilla.com
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
+import unittest
+import contextlib
+import re
+
+from cStringIO import StringIO
+from datetime import datetime, timedelta, date
+
+from mock import Mock
+
+from configman import (
+    RequiredConfig,
+    Namespace,
+    ConfigurationManager,
+    command_line
+)
+from configman.option import Option
+from configman.config_exceptions import CannotConvertError, NotAnOptionError
+from configman.value_sources.for_modules import ValueSource
+
+
+#==============================================================================
+class Alpha(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option('a', doc='a', default=17)
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.a = config.a
+
+
+#==============================================================================
+class Beta(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+        'b',
+        doc='b',
+        default=23
+    )
+
+    #--------------------------------------------------------------------------
+    def __init__(self, config):
+        self.config = config
+        self.b = config.b
+
+
+#==========================================================================
+class TestCase(unittest.TestCase):
+
+    #--------------------------------------------------------------------------
+    def test_basic_import(self):
+        config_manager = Mock()
+        vs = ValueSource('configman.tests.values_for_module_tests_1')
+        v = vs.get_values(config_manager, True)
+
+        self.assertEqual(v['a'], 18)
+        self.assertEqual(v['b'], [1, 2, 3, 3])
+        self.assertEqual(v['c'], set(v['b']))
+        self.assertEqual(v['d']['a'], v['a'])
+        self.assertEqual(v['d']['b'], v['b'])
+        self.assertEqual(v['d']['c'], v['c'])
+        self.assertEqual(v['d']['d'], {1: 'one', 2: 'two'})
+        self.assertEqual(v['foo'](1, 2, 3), '123')
+        self.assertTrue('partial' not in v)
+        self.assertEqual(v['bar'](b=8, c=9), '1889')
+        self.assertEqual(str(v['Alpha'](*list(v['c']))), '123')
+
+        self.assertFalse('x' in v)
+        self.assertFalse('y' in v)
+        self.assertFalse('os' in v)
+        self.assertTrue('collections' in v)
+
+        self.assertTrue('__package__' not in v.keys())
+        self.assertTrue('__builtins__' not in v.keys())
+        self.assertTrue('__doc__' in v.keys())
+        self.assertTrue(v.__doc__.startswith('This is a test'))
+
+        from collections import Mapping
+        self.assertTrue(v.collections.Mapping is Mapping)
+        from types import ModuleType
+        self.assertTrue(isinstance(v.collections, ModuleType))
+
+    #--------------------------------------------------------------------------
+    def test_failure_1(self):
+        """complete failure, the module does not exist"""
+        self.assertRaises(
+            CannotConvertError,
+            ValueSource,
+            'configman.tests.values_4_module_tests_1'
+        )
+
+    #--------------------------------------------------------------------------
+    def test_failure_2(self):
+        """wrong format, don't use os style paths, use dotted forms"""
+        self.assertRaises(
+            CannotConvertError,
+            ValueSource,
+            'configman/tests/test_val_for_modules.py'
+        )
+
+    #--------------------------------------------------------------------------
+    def test_as_overlay(self):
+        rc = Namespace()
+        rc.add_option(
+            'a',
+            default=23
+        )
+        rc.add_option(
+            'b',
+            default='this is b'
+        )
+        rc.namespace('n')
+        rc.n.add_option(
+            'x',
+            default=datetime(1999, 12, 31, 11, 59)
+        )
+        rc.n.add_option(
+            'y',
+            default=timedelta(3)
+        )
+        rc.n.add_option(
+            'z',
+            default=date(1650, 10, 2)
+        )
+        rc.dynamic_load = None
+
+        cm = ConfigurationManager(
+            [rc],
+            values_source_list=[
+                'configman.tests.values_for_module_tests_2',
+                'configman.tests.values_for_module_tests_3',
+            ]
+        )
+        config = cm.get_config()
+
+        self.assertEqual(config.a, 99)
+        self.assertEqual(config.b, 'now is the time')
+        self.assertEqual(config.n.x,  datetime(1960, 5, 4, 15, 10))
+        self.assertEqual(config.n.y,  timedelta(1))
+        self.assertEqual(config.n.z, date(1960, 5, 4))
+        from configman.tests.values_for_module_tests_3 import Alpha
+        self.assertEqual(config.dynamic_load, Alpha)
+        self.assertEqual(config.host, 'localhost')
+        self.assertEqual(config.port, 5432)
+
+    #--------------------------------------------------------------------------
+    def test_as_overlay_bad_symbols_with_strict(self):
+        rc = Namespace()
+        rc.add_option(
+            'a',
+            default=23
+        )
+        rc.add_option(
+            'b',
+            default='this is b'
+        )
+        rc.namespace('n')
+        rc.n.add_option(
+            'x',
+            default=datetime(1999, 12, 31, 11, 59)
+        )
+        rc.n.add_option(
+            'y',
+            default=timedelta(3)
+        )
+        rc.n.add_option(
+            'z',
+            default=date(1650, 10, 2)
+        )
+        rc.dynamic_load = None
+
+        self.assertRaises(
+            NotAnOptionError,
+            ConfigurationManager,
+            [rc],
+            values_source_list=[
+                'configman.tests.values_for_module_tests_2',
+                'configman.tests.values_for_module_tests_4',
+                command_line
+            ],
+            argv_source=['--admin.strict'],
+        )
+
+    #--------------------------------------------------------------------------
+    def test_write_simple(self):
+        rc = Namespace()
+        rc.add_option(
+            'a',
+            default=23
+        )
+        rc.add_option(
+            'b',
+            default='this is b'
+        )
+        rc.namespace('n')
+        rc.n.add_option(
+            'x',
+            default=datetime(1999, 12, 31, 11, 59)
+        )
+        rc.n.add_option(
+            'y',
+            default=timedelta(3)
+        )
+        rc.n.add_option(
+            'z',
+            default=date(1650, 10, 2)
+        )
+
+        cm = ConfigurationManager(
+            [rc],
+            values_source_list=[
+                {
+                    'a': 68,
+                    'n.x': datetime(1960, 5, 4, 15, 10),
+                    'n.y': timedelta(3),
+                    'n.z': date(2001, 1, 1)
+                }
+            ]
+        )
+        s = StringIO()
+
+        @contextlib.contextmanager
+        def s_opener():
+            yield s
+
+        cm.write_conf('py', s_opener)
+        r = s.getvalue()
+        g = {}
+        l = {}
+        exec r in g, l
+        self.assertEqual(l['a'], 68)
+        self.assertEqual(l['b'], 'this is b')
+        self.assertEqual(l['n'].x, datetime(1960, 5, 4, 15, 10))
+        self.assertEqual(l['n'].y, timedelta(3))
+        self.assertEqual(l['n'].z, date(2001, 1, 1))
+
+    #--------------------------------------------------------------------------
+    def test_write_with_imported_module(self):
+        import os
+        from configman.tests.values_for_module_tests_1 import Alpha, foo, a
+
+        definitions = {
+            'os_module': os,
+            'a': 17,
+            'imported_class': Alpha,
+            'imported_function': foo,
+            'xxx': {
+                'yyy': a,
+            }
+        }
+        cm = ConfigurationManager(
+            definitions,
+            values_source_list=[],
+        )
+        s = StringIO()
+
+        @contextlib.contextmanager
+        def s_opener():
+            yield s
+
+        cm.write_conf('py', s_opener)
+        generated_python_module_text = s.getvalue()
+        expected = """# generated Python configman file
+
+from configman.dotdict import DotDict
+from configman.tests.values_for_module_tests_1 import (
+    foo,
+    Alpha,
+)
+
+import os
+
+# the following symbols will be ignored by configman when
+# this module is used as a value source.  This will
+# suppress the mismatch warning since these symbols are
+# values for options, not option names themselves.
+ignore_symbol_list = [
+    Alpha,
+    DotDict,
+    foo,
+    os,
+]
+
+
+# a
+a = 17
+
+# imported_class
+imported_class = Alpha
+
+# imported_function
+imported_function = foo
+
+# os_module
+os_module = os
+
+# Namespace: xxx
+xxx = DotDict()
+
+# yyy
+xxx.yyy = 18
+"""
+        self.assertEqual(generated_python_module_text, expected)
+
+    #--------------------------------------------------------------------------
+    def test_write_with_imported_module_with_internal_mappings(self):
+        import os
+        from configman.tests.values_for_module_tests_1 import Alpha, foo
+
+        d = {
+            'a': 18,
+            'b': 'hello',
+            'c': [1, 2, 3],
+            'd': {
+                'host': 'localhost',
+                'port': 5432,
+            }
+        }
+
+        definitions = {
+            'os_module': os,
+            'a': 17,
+            'imported_class': Alpha,
+            'imported_function': foo,
+            'xxx': {
+                'yyy': Option('yyy', default=d)
+            },
+            'e': None,
+        }
+        required_config = Namespace()
+        required_config.add_option(
+          'minimal_version_for_understanding_refusal',
+          doc='ignore the Thottleable protocol',
+          default={'Firefox': '3.5.4'},
+        )
+
+        cm = ConfigurationManager(
+            [definitions, required_config],
+            values_source_list=[],
+        )
+
+        config = cm.get_config()
+
+        s = StringIO()
+
+        @contextlib.contextmanager
+        def s_opener():
+            yield s
+
+        cm.write_conf('py', s_opener)
+        generated_python_module_text = s.getvalue()
+
+        expected = """# generated Python configman file
+
+from configman.dotdict import DotDict
+from configman.tests.values_for_module_tests_1 import (
+    foo,
+    Alpha,
+)
+
+import os
+
+# the following symbols will be ignored by configman when
+# this module is used as a value source.  This will
+# suppress the mismatch warning since these symbols are
+# values for options, not option names themselves.
+ignore_symbol_list = [
+    Alpha,
+    DotDict,
+    foo,
+    os,
+]
+
+
+# a
+a = 17
+
+# e
+e = None
+
+# imported_class
+imported_class = Alpha
+
+# imported_function
+imported_function = foo
+
+# ignore the Thottleable protocol
+minimal_version_for_understanding_refusal = {
+    "Firefox": "3.5.4"
+}
+
+# os_module
+os_module = os
+
+# Namespace: xxx
+xxx = DotDict()
+
+xxx.yyy = {
+    "a": 18,
+    "b": "hello",
+    "c": [
+        1,
+        2,
+        3
+    ],
+    "d": {
+        "host": "localhost",
+        "port": 5432
+    }
+}
+"""
+        self.assertEqual(generated_python_module_text, expected)
+
+    #--------------------------------------------------------------------------
+    def test_write_with_imported_module_with_regex(self):
+        required_config = Namespace()
+        required_config.add_option(
+          'identifier',
+          doc='just an identifier re',
+          default=r'[a-zA-Z][a-zA-Z0-9]*',
+          from_string_converter=re.compile
+        )
+        cm = ConfigurationManager(
+            required_config,
+            values_source_list=[],
+        )
+        config = cm.get_config()
+
+        s = StringIO()
+
+        @contextlib.contextmanager
+        def s_opener():
+            yield s
+
+        cm.write_conf('py', s_opener)
+        generated_python_module_text = s.getvalue()
+        expected = """# generated Python configman file
+
+
+
+# just an identifier re
+identifier = "[a-zA-Z][a-zA-Z0-9]*"
+"""
+        self.assertEqual(generated_python_module_text, expected)
+
+
+    #--------------------------------------------------------------------------
+    def test_write_skip_aggregations(self):
+        required_config = Namespace()
+        required_config.add_option(
+          'minimal_version_for_understanding_refusal',
+          doc='ignore the Thottleable protocol',
+          default={'Firefox': '3.5.4'},
+        )
+        required_config.add_aggregation(
+            'an_agg',
+            lambda x, y, z: 'I refuse'
+        )
+
+        cm = ConfigurationManager(
+            required_config,
+            values_source_list=[],
+        )
+
+        config = cm.get_config()
+
+        s = StringIO()
+
+        @contextlib.contextmanager
+        def s_opener():
+            yield s
+
+        cm.write_conf('py', s_opener)
+        generated_python_module_text = s.getvalue()
+
+        expected = """# generated Python configman file
+
+
+
+# ignore the Thottleable protocol
+minimal_version_for_understanding_refusal = {
+    "Firefox": "3.5.4"
+}
+"""
+        self.assertEqual(generated_python_module_text, expected)
+

--- a/configman/tests/values_for_module_tests_1.py
+++ b/configman/tests/values_for_module_tests_1.py
@@ -1,0 +1,48 @@
+"""This is a test module for the configman.value_sources.for_modules
+component. It is used only with the configman.tests.test_val_for_modules tests
+"""
+# WARNING - do not change the first four words of the doc string above.  Those
+# words are used in a test in the file configman.tests.test_val_for_modules
+
+import os
+import collections
+
+a = 18
+
+b = [1, 2, 3]
+b.append(3)
+
+c = set(b)
+
+d = {
+    'a': a,
+    'b': b,
+    'c': c,
+    'd': {
+        1: 'one',
+        2: 'two',
+    }
+}
+
+
+def foo(a=None, b=None, c=None):
+    return "%s%s%s" % (a, b, c)
+
+from functools import partial
+bar = partial(foo, a=a)
+
+class Alpha(object):
+    def __init__(self, a=None, b=None, c=None):
+        self.a = a
+        self.b = b
+        self.c = c
+
+    def __str__(self):
+        return foo(self.a, self.b, self.c)
+
+
+
+x = 23
+y = 'this is private'
+
+ignore_symbol_list = ['x', 'y', 'os', 'partial']

--- a/configman/tests/values_for_module_tests_2.py
+++ b/configman/tests/values_for_module_tests_2.py
@@ -1,0 +1,21 @@
+# this file is for testing modules as an overlay source
+
+# there are two ways to get make configman ignore extra symbols in modules
+# first is the same way that is used in Mappings:
+always_ignore_mismatches = True
+# the second method is demonstrated in the values_for_module_tests_3.py file
+
+from configman.dotdict import DotDict  # will be ignored by configman
+from datetime import datetime, timedelta  # will be ignored by configman
+
+
+a = 99
+b = 86
+c = 13  # will be ignored by configman
+
+n = DotDict()
+n.x = datetime(1960, 5, 4, 15, 10)
+n.y = timedelta(1)
+
+
+

--- a/configman/tests/values_for_module_tests_3.py
+++ b/configman/tests/values_for_module_tests_3.py
@@ -1,0 +1,33 @@
+# this file is for testing modules as an overlay source
+
+# there are two ways to get make configman ignore extra symbols in modules
+# this is the second method, listing symbols to be ignored in
+# 'ignore_symbol_list':
+ignore_symbol_list = [
+    'DotDict',
+    'timedelta',
+    'date',
+    '__doc__',
+    'Alpha',
+    'RequiredConfig'
+]
+
+from configman.dotdict import DotDict
+from configman import RequiredConfig
+from datetime import timedelta, date
+
+
+b = 'now is the time'
+
+n = DotDict()
+n.y = timedelta(1)
+n.z = date(1960, 5, 4)
+
+
+class Alpha(RequiredConfig):
+    required_config = {
+        'host': 'localhost',
+        'port':  5432,
+    }
+
+dynamic_load = Alpha

--- a/configman/tests/values_for_module_tests_4.py
+++ b/configman/tests/values_for_module_tests_4.py
@@ -1,0 +1,25 @@
+# this file is for testing modules as an overlay source
+
+# none of the symbols in this file have been set to be ignored.  That means
+# that configman will warn that there are extra symbols in this file that it
+# doesn't know about.  Further, if '--admin.strict' is enabled, the extra
+# symbols are a fatal error
+
+from configman.dotdict import DotDict
+from configman import RequiredConfig
+from datetime import timedelta, date
+
+b = 'now is the time'
+
+n = DotDict()
+n.y = timedelta(1)
+n.z = date(1960, 5, 4)
+
+
+class Alpha(RequiredConfig):
+    required_config = {
+        'host': 'localhost',
+        'port':  5432,
+    }
+
+dynamic_load = Alpha

--- a/configman/value_sources/for_modules.py
+++ b/configman/value_sources/for_modules.py
@@ -1,0 +1,508 @@
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is configman
+#
+# The Initial Developer of the Original Code is
+# Mozilla Foundation
+# Portions created by the Initial Developer are Copyright (C) 2011
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#    K Lars Lohn, lars@mozilla.com
+#    Peter Bengtsson, peterbe@mozilla.com
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
+import types
+import sys
+import datetime
+import json
+import keyword
+import re
+
+from inspect import isclass, ismodule, isfunction
+from types import NoneType
+from collections import defaultdict
+
+from configman.namespace import Namespace
+from configman.dotdict import DotDict
+from configman.option import Option, Aggregation
+from configman.converters import (
+    to_str,
+    class_converter,
+    known_mapping_str_to_type,
+    CannotConvertError,
+    str_quote_stripper,
+    compiled_regexp_type
+)
+file_name_extension = 'py'
+
+
+can_handle = (
+    types.ModuleType,
+    basestring
+)
+
+#------------------------------------------------------------------------------
+# Converter Section
+#------------------------------------------------------------------------------
+
+# each value source is allowed to have its own set of converters for
+# serializing objects to strings.  This converter section defines the functions
+# that can serialize objects into Python code.  This allows writing of a
+# Python module in the same manner that ini files are written.
+
+identifier_re = re.compile(r'^[a-z_][a-z0-9_\.]*$', re.I)
+
+
+#------------------------------------------------------------------------------
+def is_identifier(a_candidate):
+    if a_candidate in keyword.kwlist:
+        return False  # identifiers can't also be keywords
+    return bool(identifier_re.match(a_candidate))
+
+#------------------------------------------------------------------------------
+def sequence_to_string(
+    a_list,
+    open_bracket_char='[',
+    close_bracket_char=']',
+    delimiter=", "
+):
+    """a dedicated function that turns a list into a comma delimited string
+    of items converted.  This method will flatten nested lists."""
+    return "%s%s%s" % (
+        open_bracket_char,
+        delimiter.join(
+            local_to_str(x)
+            for x in a_list
+        ),
+        close_bracket_char
+    )
+
+
+#------------------------------------------------------------------------------
+def dict_to_string(d):
+    return json.dumps(
+        d,
+        indent=4,
+        sort_keys=True,
+        separators=(',', ': '),
+    )
+
+
+#------------------------------------------------------------------------------
+def string_to_string(a_string):
+    quote = '"'
+    if '"' in a_string:
+        quote = "'"
+    if "'" in a_string:
+        quote = '"""'
+    if "/n" in a_string:
+        quote = "'''"
+    return "%s%s%s" % (quote, a_string, quote)
+
+
+#------------------------------------------------------------------------------
+def unicode_to_unicode(a_string):
+    quote = '"'
+    if '"' in a_string:
+        quote = "'"
+    if "'" in a_string:
+        quote = '"""'
+    if "/n" in a_string:
+        quote = "'''"
+    return "u%s%s%s" % (quote, a_string, quote)
+
+
+#------------------------------------------------------------------------------
+def datetime_to_string(d):
+    return "datetime(year=%s, month=%s, day=%s, hour=%s, " \
+        "minute=%s, second=%s)" % (
+            d.year,
+            d.month,
+            d.day,
+            d.hour,
+            d.minute,
+            d.second,
+        )
+
+
+#------------------------------------------------------------------------------
+def date_to_string(d):
+    return "date(year=%s, month=%s, day=%s)" % (
+        d.year,
+        d.month,
+        d.day,
+    )
+
+
+#------------------------------------------------------------------------------
+def timedelta_to_string(d):
+    return "timedelta(days=%s, seconds=%s)" % (
+        d.days,
+        d.seconds,
+    )
+
+
+#------------------------------------------------------------------------------
+def get_import_for_type(t):
+    """given a type, return a tuple of the (module-path, type_name)
+    or (None, None) if it is a built in."""
+    t_as_string = to_str(t)
+    if not is_identifier(t_as_string):
+        # this class expanded into something other than a single identifier
+        # we can ignore it.  This is the case when we encounter something
+        # like the configman.converter.str_to_classes_in_namespaces
+        # InnerClassList.  We can safely ignore these things here.
+        return (None, None)
+    if '.' in t_as_string:
+        parts = t_as_string.split('.')
+        return ('.'.join(parts[:-1]), parts[-1])
+    else:
+        if t_as_string in known_mapping_str_to_type:
+            return (None, None)
+        return (None, t_as_string)
+
+
+#------------------------------------------------------------------------------
+local_to_string_converters = {
+    str: string_to_string,
+    unicode: unicode_to_unicode,
+    list: sequence_to_string,
+    tuple: sequence_to_string,
+    dict: dict_to_string,
+    datetime.datetime: datetime_to_string,
+    datetime.date: date_to_string,
+    datetime.timedelta: timedelta_to_string,
+    NoneType: lambda x: "None",
+    compiled_regexp_type: lambda x: string_to_string(x.pattern)
+}
+
+
+#------------------------------------------------------------------------------
+def find_to_string_converter(a_thing):
+    for a_candidate_type, to_string_converter in local_to_string_converters:
+        if isinstance(a_thing, a_candidate_type):
+            return to_string_converter
+    return None
+
+
+#------------------------------------------------------------------------------
+def local_to_str(a_thing):
+    try:
+        return local_to_string_converters[type(a_thing)](a_thing)
+    except KeyError:
+        try:
+            return find_to_string_converter(a_thing)(a_thing)
+        except TypeError:
+            return to_str(a_thing)
+
+
+#==============================================================================
+class ValueSource(object):
+    #--------------------------------------------------------------------------
+    def __init__(self, source, the_config_manager=None):
+        if isinstance(source, basestring):
+            source = class_converter(source)
+        module_as_dotdict = DotDict()
+        try:
+            ignore_symbol_list = source.ignore_symbol_list
+            if 'ignore_symbol_list' not in ignore_symbol_list:
+                ignore_symbol_list.append('ignore_symbol_list')
+        except AttributeError:
+            ignore_symbol_list = []
+        try:
+            self.always_ignore_mismatches = source.always_ignore_mismatches
+        except AttributeError:
+            pass  # don't need to do anything - mismatches will not be ignored
+        for key, value in source.__dict__.iteritems():
+            if key.startswith('__') and key != "__doc__":
+                continue
+            if key in ignore_symbol_list:
+                continue
+            module_as_dotdict[key] = value
+        self.module = source
+        self.source = module_as_dotdict
+
+    #--------------------------------------------------------------------------
+    def get_values(self, config_manager, ignore_mismatches, obj_hook=DotDict):
+        if isinstance(self.source, obj_hook):
+            return self.source
+        return obj_hook(initializer=self.source)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def write_class(key, value, alias_by_class, output_stream):
+        if value in alias_by_class:
+            class_str = alias_by_class[value]
+        else:
+            class_str = local_to_str(value)
+        if is_identifier(class_str):
+            parts = [x.strip() for x in class_str.split('.') if x.strip()]
+            print >>output_stream, '%s = %s' % (key, parts[-1])
+        else:
+            print >>output_stream, '%s = "%s"' % (key, class_str)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def write_bare_value(key, value, output_stream):
+        if isclass(value):
+            ValueSource.write_class(key, value, output_stream)
+            return
+        try:
+            value = local_to_str(value)
+        except CannotConvertError:
+            value = repr(value)
+        if '\n' in value:
+            value = "'''%s'''" % str_quote_stripper(value)
+        print >>output_stream, '%s = %s' % (key, value)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def write_option(key, an_option, alias_by_class, output_stream):
+        print >>output_stream, '\n',
+        if an_option.doc:
+            print >>output_stream, '# %s' % an_option.doc
+        if (
+            isclass(an_option.value)
+            or ismodule(an_option.value)
+            or isfunction(an_option.value)
+        ):
+            ValueSource.write_class(
+                key,
+                an_option.value,
+                alias_by_class,
+                output_stream
+            )
+            return
+        else:
+            value = local_to_str(an_option.value)
+            print >>output_stream, '%s = %s' % (key, value)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def write_namespace(key, a_namespace, output_stream):
+        print >>output_stream, '\n# Namespace:', key
+        if hasattr(a_namespace, 'doc'):
+            print >>output_stream, '#', a_namespace.doc
+        print >>output_stream, '%s = DotDict()' % key
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def write(source_mapping, output_stream=sys.stdout):
+        """This method writes a Python module respresenting all the keys
+        and values known to configman.
+        """
+        # a set of classes, modules and/or functions that are values in
+        # configman options.  These values will have to be imported in the
+        # module that this method is writing.
+        set_of_classes_needing_imports = set()
+        # once symbols are imported, they are in the namespace of the module,
+        # but that's not where we want them.  We only want them to be values
+        # in configman Options.  This set will be used to make a list of
+        # these symbols, to forewarn a future configman that reads this
+        # module, that it can ignore these symbols. This will prevent that
+        # future configman from issuing a "mismatced symbols" warinng.
+        symbols_to_ignore = set()
+
+        # look ahead to see what sort of imports we're going to have to do
+        for key in source_mapping.keys_breadth_first():
+            value = source_mapping[key]
+
+            if isinstance(value, Aggregation):
+                # Aggregations don't get included, skip on
+                continue
+
+            if '.' in key:
+                # this indicates that there are things in nested namespaces,
+                # we will use the DotDict class to represent namespaces
+                set_of_classes_needing_imports.add(DotDict)
+
+            option = None
+            if isinstance(value, Option):
+                # it's the value inside the option, not the option itself
+                # that is of interest to us
+                option = value
+                value = option.value
+
+            if value is None:
+                # we don't need in import anything having to do with None
+                continue
+
+            if isclass(value) or ismodule(value) or isfunction(value):
+                # we know we need to import any of these types
+                set_of_classes_needing_imports.add(value)
+            else:
+                try:
+                    # perhaps the value is an instance of a class?  If so,
+                    # we'll likely need to import that class, but only if
+                    # we don't have a way to convert a string to that class
+                    set_of_classes_needing_imports.add(value.__class__)
+                except AttributeError:
+                    # it's not a class instance, we can skip on
+                    pass
+
+        # for everyone of the imports that we're going to have to create
+        # we need to know the dotted module pathname and the name of the
+        # of the class/module/function.  This routine make a list of 3-tuples
+        # class, dotted_module_path, class_name
+        class_and_module_path_and_class_name = []
+        for a_class in set_of_classes_needing_imports:
+            module_path, class_name = get_import_for_type(a_class)
+            if (not module_path) and (not class_name):
+                continue
+            class_and_module_path_and_class_name.append(
+                (a_class, module_path, class_name)
+            )
+
+        # using the collection of 3-tuples, create a lookup mapping where a
+        # class is the key to a 2-tuple of the dotted_module_path & class_name.
+        # This is also the appropriate time to detect any name collisions
+        # and create a mapping of aliases, so we can resolve name collisions.
+        class_name_by_module_path_list = defaultdict(list)
+        alias_by_class = {}
+        previously_used_names = set()
+        for (
+            a_class,
+            a_module_path,
+            class_name
+        ) in class_and_module_path_and_class_name:
+            if class_name:
+                if class_name in previously_used_names:
+                    new_class_name_alias = "%s_%s" % (
+                        a_module_path.replace('.', '_'),
+                        class_name
+                    )
+                    alias_by_class[a_class] = new_class_name_alias
+                    previously_used_names.add(new_class_name_alias)
+                else:
+                    previously_used_names.add(class_name)
+                class_name_by_module_path_list[a_module_path].append(
+                    (a_class, class_name)
+                )
+
+        # start writing the output module
+        print >>output_stream, "# generated Python configman file\n"
+
+        # the first section that we're going to write is imports of the form:
+        #     from X import Y
+        # and
+        #     from X import (
+        #         A,
+        #         B,
+        #     )
+        for a_module_path in sorted(class_name_by_module_path_list.keys()):
+            # if there is no module path, then it is something that we don't
+            # need to import.  If the module path begins with underscore then
+            # it is private and we ought not step into that mire.  If that
+            # causes the output module to fail, it is up to the implementer
+            # of the configman option to have created an approprate
+            # "from_string" & "to_string" configman Option function references.
+            if a_module_path is None or a_module_path.startswith('_'):
+                continue
+            list_of_class_names = \
+                class_name_by_module_path_list[a_module_path]
+            if len(list_of_class_names) > 1:
+                output_line = "from %s import (\n" % a_module_path
+                for a_class, a_class_name in sorted(list_of_class_names):
+                    if a_class in alias_by_class:
+                        output_line =  "%s\n    %s as %s," % (
+                            output_line,
+                            a_class_name,
+                            alias_by_class[a_class]
+                        )
+                        symbols_to_ignore.add(alias_by_class[a_class])
+                    else:
+                        output_line = "%s    %s,\n" % (
+                            output_line,
+                            a_class_name
+                        )
+                        symbols_to_ignore.add(a_class_name)
+
+                output_line = output_line + ')'
+                print >>output_stream, output_line.strip()
+            else:
+                a_class, a_class_name = list_of_class_names[0]
+                output_line = "from %s import %s" % (
+                    a_module_path,
+                    a_class_name
+                )
+                if a_class in alias_by_class:
+                    output_line = "%s as %s" % (
+                        output_line,
+                        alias_by_class[a_class]
+                    )
+                    symbols_to_ignore.add(alias_by_class[a_class])
+                else:
+                    symbols_to_ignore.add(a_class_name)
+                print >>output_stream, output_line.strip()
+        print >>output_stream, ''
+
+        # The next section to write will be the imports of the form:
+        #     import X
+        for a_module_path in sorted(class_name_by_module_path_list.keys()):
+            list_of_class_names = \
+                class_name_by_module_path_list[a_module_path]
+            a_class, a_class_name = list_of_class_names[0]
+            if a_module_path:
+                continue
+            import_str = ("import %s" % a_class_name).strip()
+            symbols_to_ignore.add(a_class_name)
+            print  >>output_stream, import_str
+
+        # See the explanation of 'symbols_to_ignore' above
+        if symbols_to_ignore:
+            print >>output_stream, "\n" \
+                "# the following symbols will be ignored by configman when\n" \
+                "# this module is used as a value source.  This will\n" \
+                "# suppress the mismatch warning since these symbols are\n" \
+                "# values for options, not option names themselves."
+            print >>output_stream, "ignore_symbol_list = ["
+            for a_symbol in symbols_to_ignore:
+                print >>output_stream, "    %s," % a_symbol
+            print >>output_stream, ']\n'
+
+        # finally, as the last step, we need to write out the keys and values
+        # will be used by a future configman as Options and values.
+        sorted_keys = sorted(
+            source_mapping.keys_breadth_first(include_dicts=True)
+        )
+        for key in sorted_keys:
+            value = source_mapping[key]
+            if isinstance(value, Namespace):
+                ValueSource.write_namespace(key, value, output_stream)
+            elif isinstance(value, Option):
+                ValueSource.write_option(
+                    key,
+                    value,
+                    alias_by_class,
+                    output_stream
+                )
+            elif isinstance(value, Aggregation):
+                # skip Aggregations
+                continue
+            else:
+                ValueSource.write_bare_value(key, value, output_stream)


### PR DESCRIPTION
this PR enables modules (specified in qualified form:  "package1.package2.module", or as instances of types.TypeModule).   

This also gives configman the ability to write modules with "--admin.print_conf=py"  
