### PR TITLE
my take on not exposing secrets

### DIFF
--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -82,8 +82,8 @@ class Namespace(dotdict.DotDict):
         setattr(current_namespace, an_option.name, an_option)
 
     #--------------------------------------------------------------------------
-    def add_aggregation(self, name, function):
-        an_aggregation = Aggregation(name, function)
+    def add_aggregation(self, name, function, secret=False):
+        an_aggregation = Aggregation(name, function, secret)
         setattr(self, name, an_aggregation)
 
     #--------------------------------------------------------------------------
@@ -137,4 +137,3 @@ class Namespace(dotdict.DotDict):
         # the __setattr__ method, this is the only way to actually force a
         # value to become an attribute rather than member of the dict
         object.__setattr__(self, '_reference_value_from', True)
-

--- a/configman/option.py
+++ b/configman/option.py
@@ -60,6 +60,7 @@ class Option(object):
         likely_to_be_changed=False,
         not_for_definition=False,
         reference_value_from=None,
+        secret=False,
     ):
         self.name = name
         self.short_form = short_form
@@ -86,6 +87,7 @@ class Option(object):
         self.likely_to_be_changed = likely_to_be_changed
         self.not_for_definition = not_for_definition
         self.reference_value_from = reference_value_from
+        self.secret = secret
 
     #--------------------------------------------------------------------------
     def __str__(self):
@@ -205,7 +207,8 @@ class Option(object):
             is_argument=self.is_argument,
             likely_to_be_changed=self.likely_to_be_changed,
             not_for_definition=self.not_for_definition,
-            reference_value_from=self.reference_value_from
+            reference_value_from=self.reference_value_from,
+            secret=self.secret,
         )
         return o
 
@@ -216,7 +219,8 @@ class Aggregation(object):
     def __init__(
         self,
         name,
-        function
+        function,
+        secret=False,
     ):
         self.name = name
         if isinstance(function, basestring):
@@ -224,6 +228,7 @@ class Aggregation(object):
         else:
             self.function = function
         self.value = None
+        self.secret = secret
 
     #--------------------------------------------------------------------------
     def aggregate(self, all_options, local_namespace, args):

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -448,7 +448,8 @@ class TestCase(unittest.TestCase):
             is_argument=False,
             likely_to_be_changed=False,
             not_for_definition=False,
-            reference_value_from='external.postgresql'
+            reference_value_from='external.postgresql',
+            secret=True,
         )
         o2 = o.copy()
         self.assertEqual(o, o2)


### PR DESCRIPTION
the idea is the default behavior is to not expose secrets.  There are times, though, when it is a handy feature to get the app itself to write out a compete config file.  

this PR adds the `--admin.expose_secrets` command line option and adds a `secret` attribute to the Options class.  If `--admin.expose_secrets` is NOT on the command line, then `--admin.print_conf`, `--admin.dump_conf` & `--help` will always an Option's value as "****************" if that Option has the attribute `secret == True`.
