### PR TITLE
fixed 'Usage' to be on one line instead of two

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -311,16 +311,28 @@ class ConfigurationManager(object):
             print >> output_stream, ''
 
         names_list = self.get_option_names()
-        print >> output_stream, (
-            "usage:\n%s [OPTIONS]..." % self.app_invocation_name
-        )
+        print >> output_stream, \
+            "usage:\n%s [OPTIONS]... " % self.app_invocation_name,
         bracket_count = 0
+        # this section prints the non-switch command line arguments
         for key in names_list:
             an_option = self.option_definitions[key]
             if an_option.is_argument:
                 if an_option.default is None:
+                    # there's no option, assume the user must set this
                     print >> output_stream, an_option.name,
+                elif (inspect.isclass(an_option.value)
+                      or inspect.ismodule(an_option.value)
+                ):
+                    # this is already set and it could have expanded, most
+                    # likely this is a case where a sub-command has been
+                    # loaded and we're looking to show the help for it.
+                    # display show it as a constant already provided rather
+                    # than as an option the user must provide
+                    print >> output_stream, an_option.default,
                 else:
+                    # this is an argument that the user may alternatively
+                    # provide
                     print >> output_stream, "[ %s" % an_option.name,
                     bracket_count += 1
         print >> output_stream, ']' * bracket_count, '\n'


### PR DESCRIPTION
a comma was left out of the code that produces the Help usage line.  That caused it to print on two lines instead of just one.  This PR adds the missing comma.

also in the same line, when a command line argument has been given a value AND the user has listed --help, we ought show the item that command line argument as an optional value.  In the context of the line provided, it is not optional, it is required. 

This is the case when a program is a launcher and the non-switch argument is a class that represents the app to run.  Git itself is a fine example:

``` bash
$ git commit --help
```

the usage line in help should list the word "commit':

``` bash
    git commit  ...
```

earlier configman didn't get this right and would instead show:

``` bash
git [ command ]
```
