### PR TITLE
travis CI deployment by tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,14 @@ script:
 notifications:
     irc:
         channels: "irc.mozilla.org#breakpad"
+
+deploy:
+    provider: pypi
+    user: peterbe
+    password:
+        secure: pLLUb5KUKlK+/G05WxbWhv0TCBqtsdgK6FylIca1EkfvVeVSEZzbL/ptSKt47cIUypm6tkbcG2QE1FzCD/Oj/JnttJyQg0UMOFnobbYqaldgDYi6LXNejG4/5SqNkMu0yabkcK0nKx2s614lCAUypvWZrX5KYh61vHT/+Asxqek=
+    on:
+        tags: true
+        repo: mozilla/configman
+        branch: travis-ci-deployment-by-tags
+    distributions: "sdist bdist_wheel"

--- a/README.md
+++ b/README.md
@@ -27,3 +27,30 @@ you might consider just using `nosetests`:
 
     nosetests configman.tests.test_config_manager:TestCase.test_write_flat
 
+
+Making a release
+----------------
+
+Because our `.travis.yml` has all the necessary information to automatically
+make a release, all you need to do is to push a tag. Most likely you will
+only want to do this after you have edited the `configman/version.txt`
+file. Suppose you make some changes:
+
+    git add configman/configman.py
+    git commit -m "fixed something"
+
+You might want to push that to your fork and make a pull request. Then,
+to update the version and make a release, first do this:
+
+    vim configman/version.txt
+    git add configman/version.txt
+    git commit -m "bump to version x.y.z"
+    git push origin master
+
+And the tag:
+
+    git tag x.y.z
+    git push origin --tags
+
+After that travis, upon a successful build will automatically make a new
+tarball and wheel and upload it to [PyPI](https://pypi.python.org/pypi/configman)


### PR DESCRIPTION
@twobraids r?

I generated the extra to `.travis.yml` using their command line tool. 
And the notes I wrote and added to the README are basically "from memory" meaning I haven't tested it. I've never been particularly good at tags so the only good way to test this is to (once this is merged) make a new release that is identical to 1.2.8 except an incremented version. 
