### PR TITLE
added opt name "password" to secrets protection

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -461,7 +461,10 @@ class ConfigurationManager(object):
                 an_option = option_defs[a_key]
                 if ((not a_key.startswith('admin'))
                     and isinstance(an_option, Option)
-                    and an_option.secret
+                    and (
+                        an_option.secret
+                        or 'password' in an_option.name.lower()
+                    )
                 ):
                     # force the option to be a string of *
                     option_defs[a_key].value = '*' * 16


### PR DESCRIPTION
I noticed while working with socorro ini files that options with "password" in the name aren't given "secrets" protection.  Considering that they _are_ given "secrets" protection during logging and via the "help" option, I figure it should be all-or-nothing.

I've extended "secrets" protection to options with "password" in the name.
