### PR TITLE
added python path as config file | corrected ignore list

### DIFF
--- a/configman/tests/test_val_for_modules.py
+++ b/configman/tests/test_val_for_modules.py
@@ -313,10 +313,10 @@ import os
 # suppress the mismatch warning since these symbols are
 # values for options, not option names themselves.
 ignore_symbol_list = [
-    Alpha,
-    DotDict,
-    foo,
-    os,
+    "Alpha",
+    "DotDict",
+    "foo",
+    "os",
 ]
 
 
@@ -403,10 +403,10 @@ import os
 # suppress the mismatch warning since these symbols are
 # values for options, not option names themselves.
 ignore_symbol_list = [
-    Alpha,
-    DotDict,
-    foo,
-    os,
+    "Alpha",
+    "DotDict",
+    "foo",
+    "os",
 ]
 
 

--- a/configman/value_sources/for_modules.py
+++ b/configman/value_sources/for_modules.py
@@ -482,7 +482,7 @@ class ValueSource(object):
                 "# values for options, not option names themselves."
             print >>output_stream, "ignore_symbol_list = ["
             for a_symbol in symbols_to_ignore:
-                print >>output_stream, "    %s," % a_symbol
+                print >>output_stream, '    "%s",' % a_symbol
             print >>output_stream, ']\n'
 
         # finally, as the last step, we need to write out the keys and values


### PR DESCRIPTION
this PR covers two flaws in the python-modules-as-config code:

1)  confgman should accept the command line form  --admin.conf=my.python.dotted.path.for.package.module
2) the module ignore list was missing its quotes.
