### PR TITLE
clean, rationalize, fix-up, and otherwise standardize imports

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -36,8 +36,8 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import os
-with open(os.path.join(os.path.dirname(__file__), 'version.txt')) as f:
+from os import path
+with open(path.join(path.dirname(__file__), 'version.txt')) as f:
     __version__ = f.read().strip()
 
 # Having these here makes it possible to easily import once configman is
@@ -47,21 +47,17 @@ with open(os.path.join(os.path.dirname(__file__), 'version.txt')) as f:
 #    from configman import Namespace, ConfigurationManager
 #
 
-from .config_manager import ConfigurationManager
-from .required_config import RequiredConfig
-from .namespace import Namespace
-
-from .converters import class_converter, regex_converter, timedelta_converter
-
-
-# constants used to refer to Value Source concepts generically
-from config_file_future_proxy import ConfigFileFutureProxy
-import getopt as command_line
-
-from os import environ
-from .dotdict import configman_keys
-environment = configman_keys(environ)
-environment.always_ignore_mismatches = True
+from configman.config_manager import ConfigurationManager
+from configman.required_config import RequiredConfig
+from configman.namespace import Namespace
+from configman.config_file_future_proxy import ConfigFileFutureProxy
+from configman.converters import (
+    class_converter,
+    regex_converter,
+    timedelta_converter
+)
+from configman.environment import environment
+from configman.command_line import command_line
 
 
 #------------------------------------------------------------------------------

--- a/configman/command_line.py
+++ b/configman/command_line.py
@@ -1,5 +1,3 @@
-import collections
-
 # ***** BEGIN LICENSE BLOCK *****
 # Version: MPL 1.1/GPL 2.0/LGPL 2.1
 #
@@ -38,36 +36,8 @@ import collections
 #
 # ***** END LICENSE BLOCK *****
 
-# TODO: This is a temporary dispatch mechanism.  This whole system
-# is to be changed to automatic discovery of the for_* modules
+# this will be expanded in the future when additional command line libraries
+# are supported
 
-from configman.def_sources import for_mappings
-from configman.def_sources import for_modules
-from configman.def_sources import for_json
+import getopt as command_line
 
-definition_dispatch = {
-  collections.Mapping: for_mappings.setup_definitions,
-  type(for_modules): for_modules.setup_definitions,
-  #list: for_list.setup_definitions,
-  str: for_json.setup_definitions,
-  unicode: for_json.setup_definitions,
-  #type: for_class.setup_definitions,
-}
-
-
-class UnknownDefinitionTypeException(Exception):
-    pass
-
-
-def setup_definitions(source, destination):
-    target_setup_func = None
-    try:
-        target_setup_func = definition_dispatch[type(source)]
-    except KeyError:
-        for a_key in definition_dispatch.keys():
-            if isinstance(source, a_key):
-                target_setup_func = definition_dispatch[a_key]
-                break
-        if not target_setup_func:
-            raise UnknownDefinitionTypeException(repr(type(source)))
-    target_setup_func(source, destination)

--- a/configman/converters.py
+++ b/configman/converters.py
@@ -42,12 +42,19 @@ import datetime
 import types
 import json
 
-from required_config import RequiredConfig
-from namespace import Namespace
+from configman.datetime_util import (
+    datetime_from_ISO_string,
+    date_from_ISO_string,
+    datetime_to_ISO_string,
+    date_to_ISO_string,
+    timedelta_to_str,
+)
 
-from .datetime_util import datetime_from_ISO_string as datetime_converter
-from .datetime_util import date_from_ISO_string as date_converter
-from .config_exceptions import CannotConvertError
+# for backward compatibility these two methods get alternate names
+datetime_converter = datetime_from_ISO_string
+date_converter = date_from_ISO_string
+
+from configman.config_exceptions import CannotConvertError
 
 import datetime_util
 
@@ -243,6 +250,11 @@ def str_to_classes_in_namespaces(
                               well as an aggregator that will instantiate the
                               class.
                               """
+
+    # these are only used within this method.  No need to pollute the module
+    # scope with them and avoid potential circular imports
+    from configman.namespace import Namespace
+    from configman.required_config import RequiredConfig
 
     #--------------------------------------------------------------------------
     def class_list_converter(class_list_str):
@@ -453,9 +465,9 @@ to_string_converters = {
     tuple: list_to_str,
     bool: lambda x: 'True' if x else 'False',
     dict: json.dumps,
-    datetime.datetime: datetime_util.datetime_to_ISO_string,
-    datetime.date: datetime_util.date_to_ISO_string,
-    datetime.timedelta: datetime_util.timedelta_to_str,
+    datetime.datetime: datetime_to_ISO_string,
+    datetime.date: date_to_ISO_string,
+    datetime.timedelta: timedelta_to_str,
     type: arbitrary_object_to_string,
     types.ModuleType: arbitrary_object_to_string,
     types.FunctionType: arbitrary_object_to_string,

--- a/configman/def_sources/for_json.py
+++ b/configman/def_sources/for_json.py
@@ -36,7 +36,7 @@
 #
 # ***** END LICENSE BLOCK *****
 import json
-import for_mappings
+from configman.def_sources import for_mappings
 
 
 def setup_definitions(source, destination):

--- a/configman/def_sources/for_mappings.py
+++ b/configman/def_sources/for_mappings.py
@@ -38,9 +38,12 @@
 
 import collections
 
-from .. import converters
-from .. import namespace
-from .. import option
+from configman.converters import str_dict_keys
+from configman.namespace import Namespace
+from configman.option import (
+    Option,
+    Aggregation,
+)
 
 
 #------------------------------------------------------------------------------
@@ -48,33 +51,33 @@ def setup_definitions(source, destination):
     for key, val in source.items():
         if key.startswith('__'):
             continue  # ignore these
-        if isinstance(val, option.Option):
+        if isinstance(val, Option):
             destination[key] = val
             if not val.name:
                 val.name = key
             val.set_value(val.default)
-        elif isinstance(val, option.Aggregation):
+        elif isinstance(val, Aggregation):
             destination[key] = val
         elif isinstance(val, collections.Mapping):
             if 'name' in val and 'default' in val:
                 # this is an Option in the form of a dict, not a Namespace
                 if key == 'not_for_definition' and val is True:
                     continue # ignore this element
-                params = converters.str_dict_keys(val)
-                destination[key] = option.Option(**params)
+                params = str_dict_keys(val)
+                destination[key] = Option(**params)
             elif 'function' in val:  # this is an Aggregation
-                params = converters.str_dict_keys(val)
-                destination[key] = option.Aggregation(**params)
+                params = str_dict_keys(val)
+                destination[key] = Aggregation(**params)
             else:
                 # this is a Namespace
                 if key not in destination:
                     try:
-                        destination[key] = namespace.Namespace(doc=val._doc)
+                        destination[key] = Namespace(doc=val._doc)
                     except AttributeError:
-                        destination[key] = namespace.Namespace()
+                        destination[key] = Namespace()
                 # recurse!
                 setup_definitions(val, destination[key])
         else:
-            destination[key] = option.Option(name=key,
+            destination[key] = Option(name=key,
                                       doc=key,
                                       default=val)

--- a/configman/def_sources/for_modules.py
+++ b/configman/def_sources/for_modules.py
@@ -36,10 +36,10 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import for_mappings
+from configman.def_sources.for_mappings import setup_definitions
 
 
 def setup_definitions(source, destination):
     module_dict = source.__dict__.copy()
     del module_dict['__builtins__']
-    for_mappings.setup_definitions(module_dict, destination)
+    setup_definitions(module_dict, destination)

--- a/configman/environment.py
+++ b/configman/environment.py
@@ -1,5 +1,3 @@
-import collections
-
 # ***** BEGIN LICENSE BLOCK *****
 # Version: MPL 1.1/GPL 2.0/LGPL 2.1
 #
@@ -38,36 +36,10 @@ import collections
 #
 # ***** END LICENSE BLOCK *****
 
-# TODO: This is a temporary dispatch mechanism.  This whole system
-# is to be changed to automatic discovery of the for_* modules
+from os import environ
 
-from configman.def_sources import for_mappings
-from configman.def_sources import for_modules
-from configman.def_sources import for_json
+from configman.dotdict import configman_keys
 
-definition_dispatch = {
-  collections.Mapping: for_mappings.setup_definitions,
-  type(for_modules): for_modules.setup_definitions,
-  #list: for_list.setup_definitions,
-  str: for_json.setup_definitions,
-  unicode: for_json.setup_definitions,
-  #type: for_class.setup_definitions,
-}
+environment = configman_keys(environ)
+environment.always_ignore_mismatches = True
 
-
-class UnknownDefinitionTypeException(Exception):
-    pass
-
-
-def setup_definitions(source, destination):
-    target_setup_func = None
-    try:
-        target_setup_func = definition_dispatch[type(source)]
-    except KeyError:
-        for a_key in definition_dispatch.keys():
-            if isinstance(source, a_key):
-                target_setup_func = definition_dispatch[a_key]
-                break
-        if not target_setup_func:
-            raise UnknownDefinitionTypeException(repr(type(source)))
-    target_setup_func(source, destination)

--- a/configman/memoize.py
+++ b/configman/memoize.py
@@ -1,3 +1,41 @@
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is configman
+#
+# The Initial Developer of the Original Code is
+# Mozilla Foundation
+# Portions created by the Initial Developer are Copyright (C) 2011
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#    K Lars Lohn, lars@mozilla.com
+#    Peter Bengtsson, peterbe@mozilla.com
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
 from functools import wraps
 
 #------------------------------------------------------------------------------

--- a/configman/namespace.py
+++ b/configman/namespace.py
@@ -36,12 +36,12 @@
 #
 # ***** END LICENSE BLOCK *****
 
-import dotdict
-from option import Option, Aggregation
+from configman.dotdict import DotDict
+from configman.option import Option, Aggregation
 
 
 #==============================================================================
-class Namespace(dotdict.DotDict):
+class Namespace(DotDict):
 
     #--------------------------------------------------------------------------
     def __init__(self, doc='', initializer=None):

--- a/configman/option.py
+++ b/configman/option.py
@@ -38,8 +38,15 @@
 
 import collections
 
-import converters as conv
-from config_exceptions import CannotConvertError, OptionError
+from configman.converters import (
+    str_to_python_object,
+    from_string_converters,
+    to_str
+)
+from configman.config_exceptions import (
+    CannotConvertError,
+    OptionError
+)
 
 
 #==============================================================================
@@ -73,7 +80,7 @@ class Option(object):
                 # take a qualified guess from the default value
                 from_string_converter = self._deduce_converter(default)
         if isinstance(from_string_converter, basestring):
-            from_string_converter = conv.class_converter(from_string_converter)
+            from_string_converter = str_to_python_object(from_string_converter)
         self.from_string_converter = from_string_converter
         # if this is not set, the type is used in converters.py to attempt
         # the conversion
@@ -100,7 +107,7 @@ class Option(object):
         try:
             return self.to_string_converter(self.value)
         except TypeError:
-            return conv.to_str(self.value)
+            return to_str(self.value)
 
     #--------------------------------------------------------------------------
     def __eq__(self, other):
@@ -128,7 +135,7 @@ class Option(object):
     def _deduce_converter(self, default):
         default_type = type(default)
 
-        return conv.str_to_instance_of_type_converters.get(
+        return from_string_converters.get(
             default_type,
             default_type
         )
@@ -224,7 +231,7 @@ class Aggregation(object):
     ):
         self.name = name
         if isinstance(function, basestring):
-            self.function = conv.class_converter(function)
+            self.function = str_to_python_object(function)
         else:
             self.function = function
         self.value = None

--- a/configman/required_config.py
+++ b/configman/required_config.py
@@ -1,4 +1,42 @@
-from .namespace import Namespace
+# ***** BEGIN LICENSE BLOCK *****
+# Version: MPL 1.1/GPL 2.0/LGPL 2.1
+#
+# The contents of this file are subject to the Mozilla Public License Version
+# 1.1 (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+# http://www.mozilla.org/MPL/
+#
+# Software distributed under the License is distributed on an "AS IS" basis,
+# WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+# for the specific language governing rights and limitations under the
+# License.
+#
+# The Original Code is configman
+#
+# The Initial Developer of the Original Code is
+# Mozilla Foundation
+# Portions created by the Initial Developer are Copyright (C) 2011
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#    K Lars Lohn, lars@mozilla.com
+#    Peter Bengtsson, peterbe@mozilla.com
+#
+# Alternatively, the contents of this file may be used under the terms of
+# either the GNU General Public License Version 2 or later (the "GPL"), or
+# the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+# in which case the provisions of the GPL or the LGPL are applicable instead
+# of those above. If you wish to allow use of your version of this file only
+# under the terms of either the GPL or the LGPL, and not to allow others to
+# use your version of this file under the terms of the MPL, indicate your
+# decision by deleting the provisions above and replace them with the notice
+# and other provisions required by the GPL or the LGPL. If you do not delete
+# the provisions above, a recipient may use your version of this file under
+# the terms of any one of the MPL, the GPL or the LGPL.
+#
+# ***** END LICENSE BLOCK *****
+
+from configman.namespace import Namespace
 
 
 #==============================================================================

--- a/configman/tests/test_config_files.py
+++ b/configman/tests/test_config_files.py
@@ -41,10 +41,14 @@ import os
 import contextlib
 
 
-import configman.datetime_util as dtu
-import configman.config_manager as config_manager
+from configman.datetime_util import (
+    datetime_from_ISO_string
+)
+from configman.namespace import Namespace
+from configman.config_manager import ConfigurationManager
+from configman.config_file_future_proxy import ConfigFileFutureProxy
 
-from configman import command_line
+from configman.command_line import command_line
 
 
 #--------------------------------------------------------------------------
@@ -59,38 +63,38 @@ def stringIO_context_wrapper(a_stringIO_instance):
 class TestCase(unittest.TestCase):
     def _some_namespaces(self):
         """set up some namespaces"""
-        n = config_manager.Namespace(doc='top')
+        n = Namespace(doc='top')
         n.add_option(
             'aaa',
             '2011-05-04T15:10:00',
             'the a',
             short_form='a',
-            from_string_converter=dtu.datetime_from_ISO_string
+            from_string_converter=datetime_from_ISO_string
         )
-        n.c = config_manager.Namespace(doc='c space')
+        n.c = Namespace(doc='c space')
         n.c.add_option(
             'dwight',
             'stupid, deadly',
             'husband from Flintstones'
         )
         n.c.add_option('wilma', "waspish's", 'wife from Flintstones')
-        n.d = config_manager.Namespace(doc='d space')
+        n.d = Namespace(doc='d space')
         n.d.add_option('dwight', "crabby", 'male neighbor from I Love Lucy')
         n.d.add_option(
             'ethel',
             'silly',
             'female neighbor from I Love Lucy'
         )
-        n.x = config_manager.Namespace(doc='x space')
+        n.x = Namespace(doc='x space')
         n.x.add_option('size', 100, 'how big in tons', short_form='s')
         n.x.add_option('password', 'secret "message"', 'the password')
         return n
 
     #----------------------------------------------------------------------
     def test_no_config_and_not_required(self):
-        config_manager.ConfigurationManager(
+        ConfigurationManager(
             definition_source=self._some_namespaces(),
-            values_source_list=[config_manager.ConfigFileFutureProxy],
+            values_source_list=[ConfigFileFutureProxy],
             app_name='dwight',
             config_pathname='.',
             config_optional=True,
@@ -100,9 +104,9 @@ class TestCase(unittest.TestCase):
     def test_no_config_and_config_required(self):
         self.assertRaises(
             IOError,
-            config_manager.ConfigurationManager,
+            ConfigurationManager,
             definition_source=self._some_namespaces(),
-            values_source_list=[config_manager.ConfigFileFutureProxy],
+            values_source_list=[ConfigFileFutureProxy],
             app_name='dwight',
             config_pathname='.',
             config_optional=False,
@@ -111,9 +115,9 @@ class TestCase(unittest.TestCase):
     #----------------------------------------------------------------------
     def test_configdir_exists_but_no_config_and_not_required(self):
         temp_config_dir = '/tmp'
-        config_manager.ConfigurationManager(
+        ConfigurationManager(
             definition_source=self._some_namespaces(),
-            values_source_list=[config_manager.ConfigFileFutureProxy],
+            values_source_list=[ConfigFileFutureProxy],
             app_name='dwight',
             config_pathname=temp_config_dir,
             config_optional=True,
@@ -124,9 +128,9 @@ class TestCase(unittest.TestCase):
         temp_config_dir = '/tmp'
         self.assertRaises(
             IOError,
-            config_manager.ConfigurationManager,
+            ConfigurationManager,
             definition_source=self._some_namespaces(),
-            values_source_list=[config_manager.ConfigFileFutureProxy],
+            values_source_list=[ConfigFileFutureProxy],
             app_name='dwight',
             config_pathname=temp_config_dir,
             config_optional=False,
@@ -138,9 +142,9 @@ class TestCase(unittest.TestCase):
         with open('/tmp/dwight.ini', 'w') as f:
             f.write('')
         try:
-            config_manager.ConfigurationManager(
+            ConfigurationManager(
                 definition_source=self._some_namespaces(),
-                values_source_list=[config_manager.ConfigFileFutureProxy],
+                values_source_list=[ConfigFileFutureProxy],
                 app_name='dwight',
                 config_pathname=temp_config_dir,
                 config_optional=True,
@@ -156,9 +160,9 @@ class TestCase(unittest.TestCase):
         with open('/tmp/dwight.ini', 'w') as f:
             f.write('[x]\n    size=42')
         try:
-            cm = config_manager.ConfigurationManager(
+            cm = ConfigurationManager(
                 definition_source=self._some_namespaces(),
-                values_source_list=[config_manager.ConfigFileFutureProxy],
+                values_source_list=[ConfigFileFutureProxy],
                 app_name='dwight',
                 config_pathname=temp_config_dir,
                 config_optional=False,
@@ -177,10 +181,10 @@ class TestCase(unittest.TestCase):
         try:
             self.assertRaises(
                 IOError,
-                config_manager.ConfigurationManager,
+                ConfigurationManager,
                 definition_source=self._some_namespaces(),
                 values_source_list=[
-                    config_manager.ConfigFileFutureProxy,
+                    ConfigFileFutureProxy,
                     command_line
                 ],
                 argv_source=['--admin.conf=wilma.ini'],
@@ -201,10 +205,10 @@ class TestCase(unittest.TestCase):
             with open('/tmp/wilma.ini', 'w') as f:
                 f.write('[x]\n    size=666')
             try:
-                cm = config_manager.ConfigurationManager(
+                cm = ConfigurationManager(
                     definition_source=self._some_namespaces(),
                     values_source_list=[
-                        config_manager.ConfigFileFutureProxy,
+                        ConfigFileFutureProxy,
                         command_line
                     ],
                     argv_source=['--admin.conf=/tmp/wilma.ini'],
@@ -228,10 +232,10 @@ class TestCase(unittest.TestCase):
             with open('./wilma.ini', 'w') as f:
                 f.write('')
             try:
-                config_manager.ConfigurationManager(
+                ConfigurationManager(
                     definition_source=self._some_namespaces(),
                     values_source_list=[
-                        config_manager.ConfigFileFutureProxy,
+                        ConfigFileFutureProxy,
                         command_line
                     ],
                     argv_source=['--admin.conf=./wilma.ini'],
@@ -256,10 +260,10 @@ class TestCase(unittest.TestCase):
             try:
                 self.assertRaises(
                     IOError,
-                    config_manager.ConfigurationManager,
+                    ConfigurationManager,
                     definition_source=self._some_namespaces(),
                     values_source_list=[
-                        config_manager.ConfigFileFutureProxy,
+                        ConfigFileFutureProxy,
                         command_line
                     ],
                     argv_source=['--admin.conf=wilma.ini'],

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -56,7 +56,7 @@ from configman.dotdict import (
 )
 from configman import Namespace, RequiredConfig
 from configman.converters import class_converter
-import configman.datetime_util as dtu
+from configman.datetime_util import datetime_from_ISO_string
 from configman.config_exceptions import NotAnOptionError
 from configman.value_sources.source_exceptions import (
     AllHandlersFailedException,
@@ -182,7 +182,7 @@ class TestCase(unittest.TestCase):
             '2011-05-04T15:10:00',
             'the a',
             short_form='a',
-            from_string_converter=dtu.datetime_from_ISO_string
+            from_string_converter=datetime_from_ISO_string
         )
         n.c = config_manager.Namespace(doc='c space')
         n.c.add_option('fred', 'stupid', 'husband from Flintstones')

--- a/configman/tests/test_def_sources.py
+++ b/configman/tests/test_def_sources.py
@@ -39,8 +39,9 @@
 import unittest
 import collections
 
-import configman.config_manager as config_manager
-import configman.dotdict as dd
+from configman.namespace import Namespace
+
+from configman.dotdict import DotDict
 import configman.def_sources as defsrc
 
 
@@ -49,7 +50,7 @@ class TestCase(unittest.TestCase):
 
     #--------------------------------------------------------------------------
     def test_setup_definitions_1(self):
-        d = dd.DotDict()
+        d = DotDict()
 
         def fake_mapping_func(source, destination):
             self.assertTrue(isinstance(source, collections.Mapping))
@@ -59,16 +60,16 @@ class TestCase(unittest.TestCase):
             defsrc.definition_dispatch[collections.Mapping] = fake_mapping_func
             s = {}
             defsrc.setup_definitions(s, d)
-            s = dd.DotDict()
+            s = DotDict()
             defsrc.setup_definitions(s, d)
-            s = config_manager.Namespace()
+            s = Namespace()
             defsrc.setup_definitions(s, d)
         finally:
             defsrc.definition_dispatch = saved_original
 
     #--------------------------------------------------------------------------
     def test_setup_definitions_2(self):
-        d = dd.DotDict()
+        d = DotDict()
 
         def fake_mapping_func(source, destination):
             self.assertTrue(source is collections)
@@ -83,7 +84,7 @@ class TestCase(unittest.TestCase):
 
     #--------------------------------------------------------------------------
     def test_setup_definitions_3(self):
-        d = dd.DotDict()
+        d = DotDict()
 
         def fake_mapping_func(source, destination):
             self.assertTrue(isinstance(source, str))

--- a/configman/tests/test_namespace.py
+++ b/configman/tests/test_namespace.py
@@ -41,7 +41,7 @@ import datetime
 import functools
 
 import configman.config_manager as config_manager
-import configman.datetime_util as dtu
+from configman.datetime_util import datetime_from_ISO_string
 
 from configman.option import Option
 from configman.orderedset import OrderedSet
@@ -66,7 +66,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(namespace.beta.default, my_birthday)
         self.assertEqual(
             namespace.beta.from_string_converter,
-            dtu.datetime_from_ISO_string
+            datetime_from_ISO_string
         )
         self.assertEqual(namespace.beta.value, my_birthday)
 

--- a/configman/tests/test_option.py
+++ b/configman/tests/test_option.py
@@ -41,8 +41,18 @@ import datetime
 import unittest
 import re
 
-import configman.converters as conv
-import configman.datetime_util as dtu
+from configman.converters import (
+    boolean_converter,
+    list_converter,
+    timedelta_converter,
+    regex_converter,
+)
+from configman.datetime_util import (
+    datetime_from_ISO_string,
+    date_from_ISO_string,
+    timedelta_to_str,
+)
+
 from configman.option import Option
 from configman.config_exceptions import CannotConvertError, OptionError
 
@@ -145,7 +155,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(o.default, d)
         self.assertEqual(o.doc, None)
         self.assertEqual(o.from_string_converter,
-                         dtu.datetime_from_ISO_string)
+                         datetime_from_ISO_string)
         self.assertEqual(o.value, d)
 
         data = {
@@ -168,13 +178,13 @@ class TestCase(unittest.TestCase):
         data = {
             'default': '2011-12-31',
             'doc': "lucy's bday",
-            'from_string_converter': dtu.date_from_ISO_string,
+            'from_string_converter': date_from_ISO_string,
         }
         o = Option('now', **data)
         self.assertEqual(o.name, 'now')
         self.assertEqual(o.default, '2011-12-31')
         self.assertEqual(o.doc, "lucy's bday")
-        self.assertEqual(o.from_string_converter, dtu.date_from_ISO_string)
+        self.assertEqual(o.from_string_converter, date_from_ISO_string)
         o.set_value()
         self.assertEqual(o.value, datetime.date(2011, 12, 31))
 
@@ -188,7 +198,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(o.name, 'now')
         self.assertEqual(o.default, '2011-12-31')
         self.assertEqual(o.doc, "lucy's bday")
-        self.assertEqual(o.from_string_converter, dtu.date_from_ISO_string)
+        self.assertEqual(o.from_string_converter, date_from_ISO_string)
         self.assertEqual(o.value, '2011-12-31')
         o.set_value()
         self.assertEqual(o.value, datetime.date(2011, 12, 31))
@@ -217,27 +227,26 @@ class TestCase(unittest.TestCase):
 
         opt = Option('name', default=False)
         self.assertEqual(opt.default, False)
-        self.assertEqual(opt.from_string_converter,
-                         conv.boolean_converter)
+        self.assertEqual(opt.from_string_converter, boolean_converter)
 
         dt = datetime.datetime(2011, 8, 10, 0, 0, 0)
         opt = Option('name', default=dt)
         self.assertEqual(opt.default, dt)
         self.assertEqual(opt.from_string_converter,
-                         dtu.datetime_from_ISO_string)
+                         datetime_from_ISO_string)
 
         dt = datetime.date(2011, 8, 10)
         opt = Option('name', default=dt)
         self.assertEqual(opt.default, dt)
         self.assertEqual(opt.from_string_converter,
-                         dtu.date_from_ISO_string)
+                         date_from_ISO_string)
 
     #--------------------------------------------------------------------------
     def test_boolean_converter_inOption(self):
         opt = Option('name', default=False)
         self.assertEqual(opt.default, False)
         self.assertEqual(opt.from_string_converter,
-                         conv.boolean_converter)
+                         boolean_converter)
 
         opt.set_value('true')
         self.assertEqual(opt.value, True)
@@ -284,7 +293,7 @@ class TestCase(unittest.TestCase):
         opt = Option('some name', default=some_list)
         self.assertEqual(opt.default, some_list)
         self.assertEqual(opt.from_string_converter,
-                         conv.list_converter)
+                         list_converter)
 
         opt.set_value('list, of, things')
         self.assertEqual(opt.value, ['list', 'of', 'things'])
@@ -295,10 +304,10 @@ class TestCase(unittest.TestCase):
         opt = Option('some name', default=one_day)
         self.assertEqual(opt.default, one_day)
         self.assertEqual(opt.from_string_converter,
-                         conv.timedelta_converter)
+                         timedelta_converter)
 
         two_days = datetime.timedelta(days=2)
-        timedelta_as_string = dtu.timedelta_to_str(two_days)
+        timedelta_as_string = timedelta_to_str(two_days)
         assert isinstance(timedelta_as_string, basestring)
         opt.set_value(timedelta_as_string)
         self.assertEqual(opt.value, two_days)
@@ -322,7 +331,7 @@ class TestCase(unittest.TestCase):
         opt = Option('name', default=sample_regex)
         self.assertEqual(opt.default, sample_regex)
         self.assertEqual(opt.from_string_converter,
-                         conv.regex_converter)
+                         regex_converter)
 
         opt.set_value(regex_str)
         self.assertEqual(opt.value.pattern, sample_regex.pattern)

--- a/configman/tests/test_val_for_conf.py
+++ b/configman/tests/test_val_for_conf.py
@@ -42,10 +42,11 @@ import tempfile
 import contextlib
 from cStringIO import StringIO
 
-import configman.datetime_util as dtu
+from configman.datetime_util import datetime_from_ISO_string
 
-from ..value_sources import for_conf
-from configman import Namespace, ConfigurationManager
+from configman.value_sources import for_conf
+from configman.namespace import Namespace
+from configman.config_manager import ConfigurationManager
 from configman.dotdict import DotDict, DotDictWithAcquisition
 
 
@@ -68,7 +69,7 @@ class TestCase(unittest.TestCase):
             '2011-05-04T15:10:00',
             'the a',
             short_form='a',
-            from_string_converter=dtu.datetime_from_ISO_string
+            from_string_converter=datetime_from_ISO_string
         )
         n.c = Namespace(doc='c space')
         n.c.add_option(

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -42,16 +42,17 @@ import tempfile
 from cStringIO import StringIO
 import contextlib
 
-import configman.datetime_util as dtu
-import configman.config_manager as config_manager
-
-from configman import Namespace
+from configman.datetime_util import (
+    datetime_from_ISO_string
+)
+from configman.namespace import Namespace
+from configman.config_manager import ConfigurationManager
 from configman.config_exceptions import NotAnOptionError
 from configman.dotdict import DotDict, DotDictWithAcquisition
 
 try:
     #from ..value_sources.for_configobj import ValueSource
-    from ..value_sources import for_configobj
+    from configman.value_sources import for_configobj
 except ImportError:
     # this module is optional.  If it doesn't exsit, that's ok, we'll just
     # igrore the tests
@@ -69,15 +70,15 @@ else:
     class TestCase(unittest.TestCase):
         def _some_namespaces(self):
             """set up some namespaces"""
-            n = config_manager.Namespace(doc='top')
+            n = Namespace(doc='top')
             n.add_option(
                 'aaa',
                 '2011-05-04T15:10:00',
                 'the a',
                 short_form='a',
-                from_string_converter=dtu.datetime_from_ISO_string
+                from_string_converter=datetime_from_ISO_string
             )
-            n.c = config_manager.Namespace(doc='c space')
+            n.c = Namespace(doc='c space')
             n.c.add_option(
                 'fred',
                 'stupid, deadly',
@@ -85,14 +86,14 @@ else:
                 ' husband from Flintstones '
             )
             n.c.add_option('wilma', "waspish's", 'wife from Flintstones')
-            n.d = config_manager.Namespace(doc='d space')
+            n.d = Namespace(doc='d space')
             n.d.add_option('fred', "crabby", 'male neighbor from I Love Lucy')
             n.d.add_option(
                 'ethel',
                 'silly',
                 'female neighbor from I Love Lucy'
             )
-            n.x = config_manager.Namespace(doc='x space')
+            n.x = Namespace(doc='x space')
             n.x.add_option('size', 100, 'how big in tons', short_form='s')
             n.x.add_option('password', 'secret "message"', 'the password')
             return n
@@ -147,7 +148,7 @@ foo=bar  # other comment
 
             try:
                 o = for_configobj.ValueSource(tmp_filename)
-                c = config_manager.ConfigurationManager(
+                c = ConfigurationManager(
                     [],
                     use_admin_controls=True,
                     #use_config_files=False,
@@ -197,7 +198,7 @@ bad_option=bar  # other comment
 
                 self.assertRaises(
                     NotAnOptionError,
-                    config_manager.ConfigurationManager,
+                    ConfigurationManager,
                     [n],
                     [tmp_filename],
                 )
@@ -208,7 +209,7 @@ bad_option=bar  # other comment
         #----------------------------------------------------------------------
         def test_write_ini(self):
             n = self._some_namespaces()
-            c = config_manager.ConfigurationManager(
+            c = ConfigurationManager(
                 [n],
                 use_admin_controls=True,
                 #use_config_files=False,
@@ -275,7 +276,7 @@ bad_option=bar  # other comment
                     }
                 }
             }
-            c = config_manager.ConfigurationManager(
+            c = ConfigurationManager(
                 [n],
                 values_source_list=[external_values],
                 use_admin_controls=True,
@@ -347,7 +348,7 @@ bad_option=bar  # other comment
             def dict_decoder(string):
                 return dict(x.split(':') for x in string.split(','))
 
-            n = config_manager.Namespace(doc='top')
+            n = Namespace(doc='top')
             n.add_option(
                 'a',
                 default={'one': 'One'},
@@ -355,7 +356,7 @@ bad_option=bar  # other comment
                 to_string_converter=dict_encoder,
                 from_string_converter=dict_decoder,
             )
-            c = config_manager.ConfigurationManager(
+            c = ConfigurationManager(
                 [n],
                 use_admin_controls=True,
                 use_auto_help=False,

--- a/configman/tests/test_val_for_getopt.py
+++ b/configman/tests/test_val_for_getopt.py
@@ -41,7 +41,7 @@ import getopt
 
 import configman.config_manager as config_manager
 from configman.config_exceptions import NotAnOptionError
-from ..value_sources.for_getopt import ValueSource
+from configman.value_sources.for_getopt import ValueSource
 from configman.dotdict import DotDict, DotDictWithAcquisition
 
 

--- a/configman/tests/test_val_for_json.py
+++ b/configman/tests/test_val_for_json.py
@@ -43,9 +43,10 @@ import tempfile
 import contextlib
 from cStringIO import StringIO
 
-import configman.config_manager as config_manager
-import configman.datetime_util as dtu
-from ..value_sources import for_json
+from configman.namespace import Namespace
+from configman.config_manager import ConfigurationManager
+from configman.datetime_util import datetime_from_ISO_string
+from configman.value_sources import for_json
 from configman.value_sources.for_json import ValueSource
 from configman.dotdict import DotDict, DotDictWithAcquisition
 
@@ -86,16 +87,16 @@ class TestCase(unittest.TestCase):
 
     #--------------------------------------------------------------------------
     def test_write_json(self):
-        n = config_manager.Namespace(doc='top')
+        n = Namespace(doc='top')
         n.add_option(
             'aaa',
             '2011-05-04T15:10:00',
             'the a',
             short_form='a',
-            from_string_converter=dtu.datetime_from_ISO_string
+            from_string_converter=datetime_from_ISO_string
         )
 
-        c = config_manager.ConfigurationManager(
+        c = ConfigurationManager(
             [n],
             use_admin_controls=True,
             use_auto_help=False,
@@ -122,15 +123,15 @@ class TestCase(unittest.TestCase):
 
     #--------------------------------------------------------------------------
     def test_json_round_trip(self):
-        n = config_manager.Namespace(doc='top')
+        n = Namespace(doc='top')
         n.add_option(
             'aaa',
             '2011-05-04T15:10:00',
             'the a',
             short_form='a',
-            from_string_converter=dtu.datetime_from_ISO_string
+            from_string_converter=datetime_from_ISO_string
         )
-        expected_date = dtu.datetime_from_ISO_string('2011-05-04T15:10:00')
+        expected_date = datetime_from_ISO_string('2011-05-04T15:10:00')
         n.add_option(
             'bbb',
             '37',
@@ -143,7 +144,7 @@ class TestCase(unittest.TestCase):
         name = '/tmp/test.json'
         import functools
         opener = functools.partial(open, name, 'w')
-        c1 = config_manager.ConfigurationManager(
+        c1 = ConfigurationManager(
             [n],
             [],
             use_admin_controls=True,
@@ -159,7 +160,7 @@ class TestCase(unittest.TestCase):
         try:
             with open(name) as jfp:
                 j = json.load(jfp)
-            c2 = config_manager.ConfigurationManager(
+            c2 = ConfigurationManager(
                 (j,),
                 (d1, d2),
                 use_admin_controls=True,

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -40,7 +40,7 @@ import collections
 import inspect
 import os
 
-from source_exceptions import (
+from configman.value_sources.source_exceptions import (
     NoHandlerForType,
     ModuleHandlesNothingException,
     AllHandlersFailedException,
@@ -50,18 +50,18 @@ from source_exceptions import (
 from configman.orderedset import OrderedSet
 from configman.converters import str_to_python_object
 
-from ..config_file_future_proxy import ConfigFileFutureProxy
-from ..config_exceptions import CannotConvertError
+from configman.config_file_future_proxy import ConfigFileFutureProxy
+from configman.config_exceptions import CannotConvertError
 
 # replace with dynamic discovery and loading
-#import for_argparse
-#import for_xml
-import for_getopt
-import for_json
-import for_conf
-import for_mapping
-import for_configobj
-import for_modules
+#from configman.value_sources import for_argparse
+#from configman.value_sources import or_xml
+from configman.value_sources import for_getopt
+from configman.value_sources import for_json
+from configman.value_sources import for_conf
+from configman.value_sources import for_mapping
+from configman.value_sources import for_configobj
+from configman.value_sources import for_modules
 
 # please replace with dynamic discovery
 for_handlers = [
@@ -140,7 +140,7 @@ for a_handler in for_handlers:
 
 
 #------------------------------------------------------------------------------
-def wrap(value_source_list, a_config_manager):
+def wrap_with_value_source_api(value_source_list, a_config_manager):
     wrapped_sources = []
     for a_source in value_source_list:
         if a_source is ConfigFileFutureProxy:
@@ -192,7 +192,7 @@ def has_registration_for(config_file_type):
 
 
 #------------------------------------------------------------------------------
-def write(config_file_type,
+def dispatch_request_to_write(config_file_type,
           options_mapping,
           opener):
 

--- a/configman/value_sources/for_conf.py
+++ b/configman/value_sources/for_conf.py
@@ -47,11 +47,14 @@ to open it.
 import functools
 import sys
 
-from .. import namespace
-from .. import option as opt
-from .. import converters
-
-from source_exceptions import ValueException, CantHandleTypeException
+from configman import namespace
+from configman.option import (
+    Option,
+)
+from configman.value_sources.source_exceptions import (
+    ValueException,
+    CantHandleTypeException
+)
 from configman.dotdict import DotDict
 from configman.memoize import memoize
 
@@ -132,7 +135,7 @@ class ValueSource(object):
         options = [
             value
             for value in source_dict.values()
-            if isinstance(value, opt.Option)
+            if isinstance(value, Option)
         ]
         options.sort(cmp=lambda x, y: cmp(x.name, y.name))
         namespaces = [

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -42,10 +42,13 @@ import os.path
 
 import configobj
 
-from source_exceptions import (CantHandleTypeException, ValueException,
-                               NotEnoughInformationException)
-from ..namespace import Namespace
-from ..option import Option
+from configman.value_sources.source_exceptions import (
+    CantHandleTypeException,
+    ValueException,
+    NotEnoughInformationException
+)
+from configman.namespace import Namespace
+from configman.option import Option
 
 from configman.dotdict import DotDict
 from configman.memoize import memoize

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -50,16 +50,18 @@ represents the argv source."""
 import getopt
 import collections
 
-from .. import dotdict
-from .. import option
-from .. import namespace
-from ..config_exceptions import NotAnOptionError
-from .. import converters as conv
-
+from configman import dotdict
+from configman import option
+from configman import namespace
+from configman.config_exceptions import NotAnOptionError
+from configman.converters import boolean_converter
 from configman.dotdict import DotDict
 from configman.memoize import memoize
 
-from source_exceptions import ValueException, CantHandleTypeException
+from configman.value_sources.source_exceptions import (
+    ValueException,
+    CantHandleTypeException
+)
 
 
 #==============================================================================
@@ -142,7 +144,7 @@ class ValueSource(object):
                         '%s is not a valid short form option' % opt_name[1:]
                     )
             option_ = config_manager._get_option(name)
-            if option_.from_string_converter == conv.boolean_converter:
+            if option_.from_string_converter == boolean_converter:
                 command_line_values[name] = not option_.default
             else:
                 command_line_values[name] = opt_val

--- a/configman/value_sources/for_json.py
+++ b/configman/value_sources/for_json.py
@@ -40,12 +40,17 @@ import json
 import collections
 import sys
 
-from .. import converters as conv
-from ..namespace import Namespace
-from ..option import Option, Aggregation
+from configman.converters import (
+    to_string_converters,
+)
+from configman.namespace import Namespace
+from configman.option import Option, Aggregation
 
-from source_exceptions import (ValueException, NotEnoughInformationException,
-                               CantHandleTypeException)
+from configman.value_sources.source_exceptions import (
+    ValueException,
+    NotEnoughInformationException,
+    CantHandleTypeException
+)
 
 from configman.dotdict import DotDict
 from configman.memoize import memoize
@@ -123,14 +128,14 @@ class ValueSource(object):
             if isinstance(val, Option):
                 for okey, oval in val.__dict__.iteritems():
                     try:
-                        d[okey] = conv.to_string_converters[type(oval)](oval)
+                        d[okey] = to_string_converters[type(oval)](oval)
                     except KeyError:
                         d[okey] = str(oval)
                 d['default'] = d['value']
             elif isinstance(val, Aggregation):
                 d['name'] = val.name
                 fn = val.function
-                d['function'] = conv.to_string_converters[type(fn)](fn)
+                d['function'] = to_string_converters[type(fn)](fn)
         json.dump(json_dict, output_stream)
 
 

--- a/configman/value_sources/for_mapping.py
+++ b/configman/value_sources/for_mapping.py
@@ -39,7 +39,7 @@
 import collections
 import os
 
-from source_exceptions import CantHandleTypeException
+from configman.value_sources.source_exceptions import CantHandleTypeException
 
 from configman.dotdict import DotDict
 from configman.memoize import memoize

--- a/configman/value_sources/source_exceptions.py
+++ b/configman/value_sources/source_exceptions.py
@@ -36,7 +36,7 @@
 #
 # ***** END LICENSE BLOCK *****
 
-from .. import config_exceptions
+from configman import config_exceptions
 
 
 class ValueException(config_exceptions.ConfigmanException):


### PR DESCRIPTION
The mess of mixed relative and absolute imports makes it difficult to work effectively on configman.  Unable to make relative imports work as expected, this PR converts them all to absolute imports.  Then going through the whole system, it changes import of entire modules into imports of the specific pieces of the modules.   That gets rid of all the module aliases (as in `import x.y as x_y`)

All this is preparation for the introduction of argparse as the command line module of choice.
