### PR TITLE
added has_changed to Option to tag modifications

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -639,6 +639,7 @@ class ConfigurationManager(object):
                         # the value source.  This assignment may come
                         # via acquisition, so the key given may not have
                         # been an exact match for what was returned.
+                        opt.has_changed = opt.default != val_src_dict[key]
                         opt.default = val_src_dict[key]
                         if key in all_reference_values:
                             # make sure that this value gets propagated to keys

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -2510,3 +2510,50 @@ c.string =   from ini
         self.assertEqual(statement.value,
              'wilma married fred using password @$*$&26Ht '
              'but divorced because of arg2.')
+
+    #--------------------------------------------------------------------------
+    def test_configmanger_set_has_changed_successfully(self):
+
+        n = config_manager.Namespace()
+        n.add_option(
+            name='dwight',
+            default=0
+        )
+        n.add_option(
+            name='wilma',
+            default=0
+        )
+        n.add_option(
+            name='sarita',
+            default=0
+        )
+        n.add_option(
+            name='robert',
+            default=0
+        )
+
+        config = config_manager.ConfigurationManager(
+            n,
+            [
+                {
+                    "dwight": 20,
+                },
+                {
+                    "dwight": 22,
+                    "wilma": 10
+                },
+                {
+                    "wilma": 0,
+                    "robert": 16,
+                },
+            ],
+            use_admin_controls=False,
+            use_auto_help=False,
+            argv_source=[]
+        )
+        self.assertTrue(config.option_definitions.dwight.has_changed)
+        self.assertFalse(config.option_definitions.wilma.has_changed)
+        self.assertFalse(config.option_definitions.sarita.has_changed)
+        self.assertTrue(config.option_definitions.robert.has_changed)
+
+

--- a/configman/tests/test_val_for_configobj.py
+++ b/configman/tests/test_val_for_configobj.py
@@ -211,6 +211,9 @@ bad_option=bar  # other comment
             n = self._some_namespaces()
             c = ConfigurationManager(
                 [n],
+                [{
+                    "c.fred": "just like George Jetson",
+                }],
                 use_admin_controls=True,
                 #use_config_files=False,
                 use_auto_help=False,
@@ -222,7 +225,7 @@ bad_option=bar  # other comment
 [c]
 
     # husband from Flintstones
-    #fred=stupid, deadly
+    fred=just like George Jetson
 
     # wife from Flintstones
     #wilma=waspish's
@@ -274,7 +277,7 @@ bad_option=bar  # other comment
                     'yyy': {
                         'password': 'dwight and wilma'
                     }
-                }
+                },
             }
             c = ConfigurationManager(
                 [n],
@@ -300,7 +303,7 @@ bad_option=bar  # other comment
 [c]
 
     # husband from Flintstones
-    #fred=stupid, deadly
+    #fred="stupid, deadly"
 
     # wife from Flintstones
     #wilma=waspish's
@@ -331,7 +334,7 @@ bad_option=bar  # other comment
 
     # the password
     # see "xxx.yyy.password" for the default or override it here
-    #password=dwight and wilma
+    password=dwight and wilma
 """)
             out = StringIO()
             c.write_conf(for_configobj, opener=stringIO_context_wrapper(out))

--- a/configman/value_sources/for_configobj.py
+++ b/configman/value_sources/for_configobj.py
@@ -250,10 +250,15 @@ class ValueSource(object):
                     )
                 )
 
-            if an_option.likely_to_be_changed:
+            if an_option.likely_to_be_changed or an_option.has_changed:
                 option_format = '%s%s=%s\n'
             else:
                 option_format = '%s#%s=%s\n'
+
+            if isinstance(option_value, basestring) and ',' in option_value:
+                # quote lists unless they're already quoted
+                if option_value[0] not in '\'"':
+                    option_value = '"%s"' % option_value
 
             print >>output_stream, option_format % (
                 indent_spacer,


### PR DESCRIPTION
when configman writes out an ini config file, it tends to comment out everything.  that means that writing a config file is a rotten method of capturing the config of a working app.  It would be great if you could tune an app to whatever config values you want and then, by writing out the config, perfectly reproduce the state of the config that will just work.  

This change monitors what config options have been changed from their defaults and ensures that when an ini file is written the changes are NOT commented out in the ini file.  
