### PR TITLE
fixed bug where expansion fails to use dicts

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -630,18 +630,23 @@ class ConfigurationManager(object):
                 try:
                     try:
                         # try to fetch new requirements from this value
-                        new_req = an_option.value.get_required_config()
+                        new_requirements = \
+                            an_option.value.get_required_config()
                     except AttributeError:
-                        new_req = an_option.value.required_config
+                        new_requirements = an_option.value.required_config
                     # make sure what we got as new_req is actually a
                     # Mapping of some sort
-                    if not isinstance(new_req, collections.Mapping):
+                    if not isinstance(new_requirements, collections.Mapping):
                         # we didn't get a mapping, perhaps the option value
                         # was a Mock object - in any case we can't try to
                         # interpret 'new_req' as a configman requirement
                         # collection.  We must abandon processing this
                         # option further
                         continue
+                    if not isinstance(new_requirements, Namespace):
+                        new_requirements = Namespace(
+                            initializer=new_requirements
+                        )
                     # get the parent namespace
                     current_namespace = self.option_definitions.parent(key)
                     if current_namespace is None:
@@ -657,12 +662,13 @@ class ConfigurationManager(object):
                     # as unseen so that the new default doesn't overwrite any
                     # of the overlays that have already taken place.
                     known_keys = known_keys.difference(
-                        known_keys.intersection(new_req.keys())
+                        known_keys.intersection(new_requirements.keys())
                     )
                     # add the new Options to the namespace
-                    new_namespace = new_req.safe_copy(
+                    new_namespace = new_requirements.safe_copy(
                         an_option.reference_value_from
                     )
+
                     for new_key in new_namespace.keys_breadth_first():
                         if new_key not in current_namespace:
                             current_namespace[new_key] = new_namespace[new_key]

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -2268,6 +2268,39 @@ c.string =   from ini
         self.assertEqual(cn.a.fred, 21)
 
     #--------------------------------------------------------------------------
+    def test_expansion_new_req_as_dict_bug(self):
+        # when a class is expanded and that class has required config that is
+        # of Mapping that is not a Namespace or DotDict, adding those
+        # requirements has been failing.  Test that it now works after a change
+        # that converts them to Namespaces during the expansion process.
+        class A(RequiredConfig):
+            @staticmethod
+            def get_required_config():
+                return {
+                    "alpha": 1,
+                    "beta": True,
+                    "gamma": "hello",
+                }
+
+        r = Namespace()
+        r.add_option(
+            'some_class',
+            default=A,
+            from_string_converter=class_converter,
+        )
+
+        cm = config_manager.ConfigurationManager(
+            definition_source=[r],
+            values_source_list=[],
+            argv_source=[]
+        )
+        cn = cm.get_config()
+
+        self.assertEqual(cn.alpha, 1)
+        self.assertTrue(cn.beta)
+        self.assertEqual(cn.gamma, 'hello')
+
+    #--------------------------------------------------------------------------
     def test_value_source_object_hook_1(self):
         """the definition source defines only keys with underscores.
         the value sources may have hyphens instead of underscores.


### PR DESCRIPTION
Classes are allowed to use plane old `dict` instances to specify required configuration rather than using namespaces.  While that works fine in defining initial requirements, it wasn't working in the dynamic expansion of classes.    This PR fixes that problem by ensuring that all required config in any Mapping type coming in during expansion is properly converted to Namespace.
