### PR TITLE
no mergy - demo only - added support for argparse

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -22,8 +22,16 @@ from configman.converters import (
     regex_converter,
     timedelta_converter
 )
+
 from configman.environment import environment
-from configman.command_line import command_line
+# this next line brings in command_line and, if argparse is available,
+# a definition of the configman version of ArgumentParser.  Why is it done
+# with "import *" ? Because I don't know what symbols to import, the decision
+# about what is symbols exist within the module.  To make the import specific
+# here, it would be necessary to reproduce the same logic that is already
+# in the commandline module.
+from configman.commandline import *
+
 
 
 #------------------------------------------------------------------------------

--- a/configman/command_line.py
+++ b/configman/command_line.py
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# this will be expanded in the future when additional command line libraries
-# are supported
-
-import getopt as command_line
-

--- a/configman/commandline.py
+++ b/configman/commandline.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# this will be expanded in the future when additional command line libraries
+# are supported
+
+# at which point we want to make argparse the default, we will eliminate
+# this line
+import getopt as command_lineh
+
+try:
+    import argparse as command_line
+    from configman.def_sources.for_argparse import ArgumentParser
+except ImportError:
+    # argpparse is not available, we can silently ignore this problem
+    pass

--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -15,30 +15,46 @@ import warnings
 # for convenience define some external symbols here - some client modules may
 # import these symbols from here rather than their origin definition location.
 # PyFlakes may erroneously flag some of these as unused
-from configman.command_line import command_line
-from configman.converters import to_string_converters
-from configman.config_exceptions import NotAnOptionError
-from configman.config_file_future_proxy import ConfigFileFutureProxy
-from configman.def_sources import setup_definitions
+from configman.commandline import (
+    command_line
+)
+from configman.converters import (
+    to_string_converters,
+)
+from configman.config_exceptions import (
+    NotAnOptionError,
+)
+from configman.config_file_future_proxy import (
+    ConfigFileFutureProxy
+)
+from configman.def_sources import (
+    setup_definitions,
+)
 from configman.dotdict import (
     DotDict,
     DotDictWithAcquisition,
     iteritems_breadth_first
 )
-from configman.environment import environment
-from configman.namespace import Namespace
+from configman.environment import (
+    environment
+)
+from configman.namespace import (
+    Namespace
+)
 from configman.option import (
     Option,
     Aggregation
 )
-# The following is not used directly in this file, but made available as
-# a type to be imported from this module
-from configman.required_config import RequiredConfig
+from configman.required_config import (
+    RequiredConfig  # not used directly in this file, but made available as
+                    # a type to be imported from this module
+)
 from configman.value_sources import (
     config_filename_from_commandline,
     wrap_with_value_source_api,
     dispatch_request_to_write,
     file_extension_dispatch,
+    type_handler_dispatch
 )
 
 
@@ -133,6 +149,8 @@ class ConfigurationManager(object):
         self.config_pathname = config_pathname
         self.config_optional = config_optional
 
+        self.use_auto_help = use_auto_help
+
         self.value_source_object_hook = value_source_object_hook
 
         self.app_name = app_name
@@ -147,19 +165,46 @@ class ConfigurationManager(object):
         self.option_definitions = Namespace()
         self.definition_source_list = definition_source_list
 
+        command_line_value_source = command_line
         if values_source_list is None:
             # nothing set, assume defaults
             if use_admin_controls:
                 values_source_list = (
                     ConfigFileFutureProxy,
                     environment,
-                    command_line
+                    command_line_value_source
                 )
             else:
                 values_source_list = (
                     environment,
-                    command_line
+                    command_line_value_source
                 )
+        # determine which command_line facility to use for help
+        if self.use_auto_help:
+            # we need to iterate through all of our value sources looking for
+            # one that can interact with the user on the commandline.
+            for a_value_source in values_source_list:
+                if inspect.ismodule(a_value_source):
+                    handler = \
+                        type_handler_dispatch[a_value_source][0].ValueSource
+                    try:
+                        # if a value source is able to handle the command line
+                        # it will have defined 'command_line_value_source' as
+                        # true.  Not all values sources may have this attribute
+                        if handler.command_line_value_source:
+                            handler._setup_auto_help(self)
+                            break
+                    except AttributeError:
+                        # not a commandline source because it doesn't have
+                        # the 'command_line_value_source' OR it doesn't have
+                        # a method that allows it to setup a help system.
+                        # this is OK, we can ignore it an move on until we
+                        # find an appropriate source.
+                        pass
+                # else:
+                    # this object is not actually a proper value source object
+                    # so we know nothing about its interface.  We cannot even
+                    # try to use it as a commandline value source.
 
         admin_tasks_done = False
         self.admin_controls_list = [
@@ -172,8 +217,6 @@ class ConfigurationManager(object):
         ]
         self.options_banned_from_help = options_banned_from_help
 
-        if use_auto_help:
-            self._setup_auto_help()
         if use_admin_controls:
             admin_options = self._setup_admin_options(values_source_list)
             self.definition_source_list.append(admin_options)
@@ -234,9 +277,23 @@ class ConfigurationManager(object):
             # 'app_name' from the parameters passed in, if they exist.
             pass
 
-        if use_auto_help and self._get_option('help').value:
-            self.output_summary()
-            admin_tasks_done = True
+        try:
+            if use_auto_help and self._get_option('help').value:
+                self.output_summary()
+                admin_tasks_done = True
+        except NotAnOptionError:
+            # the current command-line implementation already has a help
+            # mechanism of its own that doesn't required the use of a
+            # option in configman.  This error is ignorable
+            pass
+
+        keys_blocked_by_suffix = [
+            key
+            for key in self.option_definitions.keys_breadth_first()
+            if key.endswith('$')
+        ]
+        if keys_blocked_by_suffix:
+            self.admin_controls_list.extend(keys_blocked_by_suffix)
 
         if use_admin_controls and self._get_option('admin.print_conf').value:
             self.print_conf()
@@ -300,8 +357,9 @@ class ConfigurationManager(object):
                 if an_option.default is None:
                     # there's no option, assume the user must set this
                     print >> output_stream, an_option.name,
-                elif (inspect.isclass(an_option.value)
-                      or inspect.ismodule(an_option.value)
+                elif (
+                    inspect.isclass(an_option.value)
+                    or inspect.ismodule(an_option.value)
                 ):
                     # this is already set and it could have expanded, most
                     # likely this is a case where a sub-command has been
@@ -344,8 +402,10 @@ class ConfigurationManager(object):
             except KeyError:
                 default = option.value
             if default is not None:
-                if ((option.secret or 'password' in name.lower())
-                    and not self.option_definitions.admin.expose_secrets.default):
+                if (
+                    (option.secret or 'password' in name.lower()) and
+                    not self.option_definitions.admin.expose_secrets.default
+                ):
                     default = '*********'
                 if name not in ('help',):
                     # don't bother with certain dead obvious ones
@@ -434,11 +494,13 @@ class ConfigurationManager(object):
         else:
             option_defs = self.option_definitions
 
-        # find all of the secret options and overwrite their values with '*' * 16
+        # find all of the secret options and overwrite their values with
+        # '*' * 16
         if not self.option_definitions.admin.expose_secrets.default:
             for a_key in option_defs.keys_breadth_first():
                 an_option = option_defs[a_key]
-                if ((not a_key.startswith('admin'))
+                if (
+                    (not a_key.startswith('admin'))
                     and isinstance(an_option, Option)
                     and an_option.secret
                 ):
@@ -566,10 +628,18 @@ class ConfigurationManager(object):
                     all_reference_values[a_ref_value_key] = []
             all_keys = list(set_of_reference_value_from_links) + keys
 
+            values_from_all_sources = [
+                a_value_source.get_values(
+                    self,  # pass in the config_manager itself
+                    True,  # ignore mismatches
+                    self.value_source_object_hook  # build with this class
+                )
+                for a_value_source in self.values_source_list
+            ]
+
             # overlay process:
             # fetch all the default values from the value sources before
             # applying the from string conversions
-            #
 
             for key in (k for k in all_keys if k not in known_keys):
                 #if not isinstance(an_option, Option):
@@ -591,22 +661,23 @@ class ConfigurationManager(object):
                         key
                     )
 
-                for a_value_source in self.values_source_list:
+                an_option = self.option_definitions[key]
+                if key in all_reference_values:
+                    # make sure that this value gets propagated to keys
+                    # even if the keys have already been overlaid
+                    known_keys -= set(all_reference_values[key])
+
+                for val_src_dict in values_from_all_sources:
                     try:
-                        # get all the option values from this value source
-                        val_src_dict = a_value_source.get_values(
-                            self,
-                            True,
-                            self.value_source_object_hook
-                        )
-                        # get the Option for this key
-                        opt = self.option_definitions[key]
+
                         # overlay the default with the new value from
                         # the value source.  This assignment may come
                         # via acquisition, so the key given may not have
                         # been an exact match for what was returned.
-                        opt.has_changed = opt.default != val_src_dict[key]
-                        opt.default = val_src_dict[key]
+                        an_option.has_changed = (
+                            an_option.default != val_src_dict[key]
+                        )
+                        an_option.default = val_src_dict[key]
                         if key in all_reference_values:
                             # make sure that this value gets propagated to keys
                             # even if the keys have already been overlaid
@@ -632,8 +703,11 @@ class ConfigurationManager(object):
                         # try to fetch new requirements from this value
                         new_requirements = \
                             an_option.value.get_required_config()
-                    except AttributeError:
-                        new_requirements = an_option.value.required_config
+                    except (AttributeError, KeyError):
+                        if hasattr(an_option.value, 'required_config'):
+                            new_requirements = an_option.value.required_config
+                        else:
+                            new_requirements = None
                     # make sure what we got as new_req is actually a
                     # Mapping of some sort
                     if not isinstance(new_requirements, collections.Mapping):
@@ -825,6 +899,8 @@ class ConfigurationManager(object):
     #--------------------------------------------------------------------------
     def _walk_config_copy_values(self, source, destination, mapping_class):
         for key, val in source.items():
+            if key.endswith('$'):
+                continue
             value_type = type(val)
             if isinstance(val, Option) or isinstance(val, Aggregation):
                 destination[key] = val.value

--- a/configman/converters.py
+++ b/configman/converters.py
@@ -412,8 +412,8 @@ py_obj_to_str = arbitrary_object_to_string  # for backwards compatibility
 
 
 #------------------------------------------------------------------------------
-def list_to_str(a_list):
-    return ', '.join(to_str(x) for x in a_list)
+def list_to_str(a_list, delimiter=', '):
+    return delimiter.join(to_str(x) for x in a_list)
 
 #------------------------------------------------------------------------------
 known_mapping_type_to_str = dict(

--- a/configman/def_sources/__init__.py
+++ b/configman/def_sources/__init__.py
@@ -14,11 +14,19 @@ from configman.def_sources import for_json
 definition_dispatch = {
   collections.Mapping: for_mappings.setup_definitions,
   type(for_modules): for_modules.setup_definitions,
-  #list: for_list.setup_definitions,
   str: for_json.setup_definitions,
   unicode: for_json.setup_definitions,
-  #type: for_class.setup_definitions,
 }
+
+
+try:
+    from configman.def_sources import for_argparse
+    import argparse
+    definition_dispatch[argparse.ArgumentParser] = \
+        for_argparse.setup_definitions
+except ImportError:
+    # silently ignore that argparse doesn't exist
+    pass
 
 
 class UnknownDefinitionTypeException(Exception):

--- a/configman/def_sources/for_argparse.py
+++ b/configman/def_sources/for_argparse.py
@@ -2,13 +2,651 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# this is a stub for future implementation
+"""this module introduces support for argparse as a data definition source
+for configman.  Rather than write using configman's data definition language,
+programs can instead use the familiar argparse method."""
 
-try:
-    import argparse
+import argparse
+import inspect
+from os import environ
+from functools import partial
 
-    def setup_definitions(source, destination):
-        pass
+from configman.namespace import Namespace
+from configman.config_file_future_proxy import ConfigFileFutureProxy
+from configman.dotdict import (
+    DotDict,
+    iteritems_breadth_first,
+    create_key_translating_dot_dict
+)
+from configman.converters import (
+    str_to_instance_of_type_converters,
+    str_to_list,
+    boolean_converter,
+    to_str,
+    CannotConvertError
+)
 
-except ImportError:
-    pass
+
+#-----------------------------------------------------------------------------
+# horrors
+# argparse is not very friendly toward extension in this manner.  In order to
+# fully exploit argparse, it is necessary to reach inside it to examine some
+# of its internal structures that are not intended for external use.  These
+# invasive methods are restricted to read-only.
+#------------------------------------------------------------------------------
+def find_action_name_by_value(registry, target_action_instance):
+    """the association of a name of an action class with a human readable
+    string is exposed externally only at the time of argument definitions.
+    This routine, when given a reference to argparse's internal action
+    registry and an action, will find that action and return the name under
+    which it was registered.
+    """
+    target_type = type(target_action_instance)
+    for key, value in registry['action'].iteritems():
+        if value is target_type:
+            if key is None:
+                return 'store'
+            return key
+    return None
+
+
+#------------------------------------------------------------------------------
+def get_args_and_values(parser, an_action):
+    """this rountine attempts to reconstruct the kwargs that were used in the
+    creation of an action object"""
+    args = inspect.getargspec(an_action.__class__.__init__).args
+    kwargs = dict(
+        (an_attr, getattr(an_action, an_attr))
+        for an_attr in args
+        if (
+            an_attr not in ('self', 'required')
+            and getattr(an_action, an_attr) is not None
+        )
+    )
+    action_name = find_action_name_by_value(
+        parser._optionals._registries,
+        an_action
+    )
+    if 'required' in kwargs:
+        del kwargs['required']
+    kwargs['action'] = action_name
+    if 'option_strings' in kwargs:
+        args = tuple(kwargs['option_strings'])
+        del kwargs['option_strings']
+    else:
+        args = ()
+    return args, kwargs
+
+
+#==============================================================================
+class SubparserFromStringConverter(object):
+    """this class serves as both a repository of namespace sets corresponding
+    with subparsers, and a from string converer. It is used in configman as the
+    from_string_converter for the Option that corresponds with the subparser
+    argparse action.  Once configman as assigned the final value to the
+    subparser, it leaves an instance of the SebparserValue class as the default
+    for the subparser configman option.  A deriviative of a string, this class
+    also contains the configman required config corresponding to the actions
+    of the subparsers."""
+    #--------------------------------------------------------------------------
+    def __init__(self):
+        self.namespaces = {}
+
+    #--------------------------------------------------------------------------
+    def add_namespace(self, name, a_namespace):
+        """as we build up argparse, the actions that define a subparser are
+        translated into configman options.  Each of those options must be
+        tagged with the value of the subparse to which they correspond."""
+        # save a local copy of the namespace
+        self.namespaces[name] = a_namespace
+        # iterate through the namespace branding each of the options with the
+        # name of the subparser to which they belong
+        for k in a_namespace.keys_breadth_first():
+            an_option = a_namespace[k]
+            if not an_option.foreign_data:
+                an_option.foreign_data = DotDict()
+            an_option.foreign_data['argparse.owning_subparser_name'] = name
+
+    #--------------------------------------------------------------------------
+    def __call__(self, subparser_name):
+        """As an instance of this class must serve as a from_string_converter,
+        it must behave like a function.  This method gives an instance of this
+        class function semantics"""
+        #======================================================================
+        class SubparserValue(str):
+            """Instances of this class/closure serve as the value given out as
+            the final value of the subparser configman option.  It is a string,
+            that also has a 'get_required_config' method that can bring in the
+            the arguments defined in the subparser in the local namespace.
+            The mechanism works in the same manner that configman normally does
+            expansion of dynamically loaded classes."""
+            required_config = Namespace()
+            try:
+                # define the class dynamically, giving it the required_config
+                # that corresponds with the confiman options defined for the
+                # subparser of the same name.
+                required_config = self.namespaces[subparser_name]
+            except KeyError:
+                raise CannotConvertError(
+                    '%s is not a known sub-command' % subparser_name
+                )
+
+            #------------------------------------------------------------------
+            def __new__(cls):
+                """deriving from string is tricky business.  You cannot set the
+                value in an __init__ method because strings are immutable and
+                __init__ time is too late.  The 'new' method is the only chance
+                to properly set the value."""
+                obj = str.__new__(cls, subparser_name)
+                return obj
+
+            #------------------------------------------------------------------
+            def get_required_config(self):
+                return self.required_config
+
+            #------------------------------------------------------------------
+            def to_str(self):
+                return subparser_name
+        # instantiate the class and return it.  It will be assigned as the
+        # value for the configman option corresponding with the subparser
+        return SubparserValue()
+
+
+#==============================================================================
+class ConfigmanSubParsersAction(argparse._SubParsersAction):
+    """this is a derivation of the argpares _SubParsersAction action.  We
+    require its use over the default _SubParsersAction because we need to
+    preserve the original args & kwargs that created it.  They will be used
+    in a later phase of configman to perfectly reproduce the object without
+    having to resort to a copy."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.original_args = args
+        self.original_kwargs = kwargs
+        super(ConfigmanSubParsersAction, self).__init__(*args, **kwargs)
+
+    #--------------------------------------------------------------------------
+    def add_parser(self, *args, **kwargs):
+        """each time a subparser action is used to create a new parser object
+        we must save the original args & kwargs.  In a later phase of
+        configman, we'll need to reproduce the subparsers exactly without
+        resorting to copying.  We save the args & kwargs in the 'foreign_data'
+        section of the configman option that corresponds with the subparser
+        action."""
+        command_name = args[0]
+        new_kwargs = kwargs.copy()
+        new_kwargs['configman_subparsers_option'] = self._configman_option
+        new_kwargs['subparser_name'] = command_name
+        subparsers = self._configman_option.foreign_data.argparse.subparsers
+        a_subparser = super(ConfigmanSubParsersAction, self).add_parser(
+            *args,
+            **new_kwargs
+        )
+        subparsers[command_name] = DotDict({
+            "args": args,
+            "kwargs": new_kwargs,
+            "subparser": a_subparser
+        })
+        return a_subparser
+
+    #--------------------------------------------------------------------------
+    def add_configman_option(self, an_option):
+        self._configman_option = an_option
+
+
+#==============================================================================
+class ArgumentParser(argparse.ArgumentParser):
+    """this subclass of the standard argparse parser to be used as a drop in
+    replacement for argparse.ArgumentParser.  It hijacks the standard
+    parsing methods and hands off to configman.  Configman then calls back
+    to the standard argparse base class to actually do the work, intercepting
+    the final output do its overlay magic. The final result is not an
+    argparse Namespace object, but a configman DotDict.  This means that it
+    is functionlly equivalent to the argparse Namespace with the additional
+    benefit of being compliant with the collections.Mapping abstract base
+    class."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.original_args = args
+        self.original_kwargs = kwargs.copy()
+        kwargs['add_help'] = False  # stop help, reintroduce it later
+        self.subparser_name = kwargs.pop('subparser_name', None)
+        self.configman_subparsers_option = kwargs.pop(
+            'configman_subparsers_option',
+            None
+        )
+        super(ArgumentParser, self).__init__(*args, **kwargs)
+        self.value_source_list = [environ, ConfigFileFutureProxy, argparse]
+        self.required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    def get_required_config(self):
+        """because of the exsistance of subparsers, the configman options
+        that correspond with argparse arguments are not a constant.  We need
+        to produce a copy of the namespace rather than the actual embedded
+        namespace."""
+        required_config = Namespace()
+        # add current options to a copy of required config
+        for k, v in iteritems_breadth_first(self.required_config):
+            required_config[k] = v
+        # get any option found in any subparsers
+        try:
+            subparser_namespaces = (
+                self.configman_subparsers_option.foreign_data
+                .argparse.subprocessor_from_string_converter
+            )
+            subparsers = (
+                self._argparse_subparsers._configman_option.foreign_data
+                .argparse.subparsers
+            )
+            # each subparser needs to have its configman options set up
+            # in the subparser's configman option.  This routine copies
+            # the required_config of each subparser into the
+            # SubparserFromStringConverter defined above.
+            for subparser_name, subparser_data in subparsers.iteritems():
+                subparser_namespaces.add_namespace(
+                    subparser_name,
+                    subparser_data.subparser.get_required_config()
+                )
+        except AttributeError:
+            # there is no subparser
+            pass
+        return required_config
+
+    #--------------------------------------------------------------------------
+    def add_argument(self, *args, **kwargs):
+        """this method overrides the standard in order to create a parallel
+        argument system in both the argparse and configman worlds.  Each call
+        to this method returns a standard argparse Action object as well as
+        adding an equivalent configman Option object to the required_config
+        for this object.  The original args & kwargs that defined an argparse
+        argument are preserved in the 'foreign_data' section of the
+        corresponding configman Option."""
+        # pull out each of the argument definition components from the args
+        # so that we can deal with them one at a time in a well labeled manner
+        # In this section, variables beginning with the prefix "argparse" are
+        # values that define Action object.  Variables that begin with
+        # "configman" are the arguments to create configman Options.
+        argparse_action_name = kwargs.get('action', None)
+        argparse_dest = kwargs.get('dest', None)
+        argparse_const = kwargs.get('const', None)
+        argparse_default = kwargs.get('default', None)
+        if argparse_default is argparse.SUPPRESS:
+            # we'll be forcing all options to have the attribute of
+            # argparse.SUPPRESS later.  It's our way of making sure that
+            # argparse returns only values that the user explicitly added to
+            # the command line.
+            argparse_default = None
+        argparse_nargs = kwargs.get('nargs', None)
+        argparse_type = kwargs.get('type', None)
+        argparse_suppress_help = kwargs.pop('suppress_help', False)
+        if argparse_suppress_help:
+            configman_doc = kwargs.get('help', '')
+            kwargs['help'] = argparse.SUPPRESS
+        else:
+            argparse_help = kwargs.get('help', '')
+            if argparse_help == argparse.SUPPRESS:
+                configman_doc = ''
+            else:
+                configman_doc = argparse_help
+
+        # we need to make sure that all arguments that the user has not
+        # explicily set on the command line have this attribute.  This means
+        # that when the argparse parser returns the command line values, it
+        # will not return values that the user did not mention on the command
+        # line.  The defaults that otherwise would have been returned will be
+        # handled by configman.
+        kwargs['default'] = argparse.SUPPRESS
+        # forward all parameters to the underlying base class to create a
+        # normal argparse action object.
+        an_action = super(ArgumentParser, self).add_argument(
+            *args,
+            **kwargs
+        )
+        argparse_option_strings = an_action.option_strings
+
+        # get a human readable string that identifies the type of the argparse
+        # action class that was created
+        if argparse_action_name is None:
+            argparse_action_name = find_action_name_by_value(
+                self._optionals._registries,
+                an_action
+            )
+
+        configman_is_argument = False
+
+        # each of argparse's Action types must be handled separately.
+        #--------------------------------------------------------------------
+        # STORE
+        if argparse_action_name == 'store':
+            if argparse_dest is None:
+                configman_name = args[0]
+                removed_prefix = False
+                for x in range(2):
+                    if configman_name[0] in self.prefix_chars:
+                        configman_name = configman_name[1:]
+                        removed_prefix = True
+                configman_is_argument = not removed_prefix
+            else:
+                configman_name = argparse_dest
+                configman_is_argument = not argparse_option_strings
+            configman_default = argparse_default
+            if argparse_nargs and argparse_nargs in "1?":
+                if argparse_type:
+                    configman_from_string = argparse_type
+                elif argparse_default:
+                    configman_from_string = (
+                        str_to_instance_of_type_converters.get(
+                            type(argparse_default),
+                            str
+                        )
+                    )
+                else:
+                    configman_from_string = str
+            elif argparse_nargs and argparse_type:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=argparse_type,
+                    item_separator=' ',
+                )
+            elif argparse_nargs and argparse_default:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=str_to_instance_of_type_converters.get(
+                        type(argparse_default),
+                        str
+                    ),
+                    item_separator=' ',
+                )
+            elif argparse_nargs:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=str,
+                    item_separator=' ',
+                )
+            elif argparse_type:
+                configman_from_string = argparse_type
+            elif argparse_default:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_default),
+                    str
+                )
+            else:
+                configman_from_string = str
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # STORE_CONST
+        elif argparse_action_name == 'store_const':
+            if argparse_dest is None:
+                configman_name = args[0]
+                for x in range(2):
+                    if configman_name[0] in self.prefix_chars:
+                        configman_name = configman_name[1:]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_const),
+                    str
+                )
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # STORE_TRUE /  STORE_FALSE
+        elif (
+            argparse_action_name == 'store_true'
+            or argparse_action_name == 'store_false'
+        ):
+            if argparse_dest is None:
+                configman_name = args[0]
+                for x in range(2):
+                    if configman_name[0] in self.prefix_chars:
+                        configman_name = configman_name[1:]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            configman_from_string = boolean_converter
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # APPEND
+        elif argparse_action_name == 'append':
+            if argparse_dest is None:
+                configman_name = args[0]
+                for x in range(2):
+                    if configman_name[0] in self.prefix_chars:
+                        configman_name = configman_name[1:]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # APPEND_CONST
+        elif argparse_action_name == 'append_const':
+            if argparse_dest is None:
+                configman_name = args[0]
+                for x in range(2):
+                    if configman_name[0] in self.prefix_chars:
+                        configman_name = configman_name[1:]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_const),
+                    str
+                )
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # VERSION
+        elif argparse_action_name == 'version':
+            return an_action
+
+        #--------------------------------------------------------------------
+        # OTHER
+        else:
+            configman_name = argparse_dest
+
+        # configman uses the switch name as the name of the key inwhich to
+        # store values.  argparse is able to use different names for each.
+        # this means that configman may encounter repeated targets.  Rather
+        # than overwriting Options with new ones with the same name, configman
+        # renames them by appending the '$' character.
+        while configman_name in self.required_config:
+            configman_name = "%s$" % configman_name
+        configman_not_for_definition = configman_name.endswith('$')
+
+        # it's finally time to create the configman Option object and add it
+        # to the required_config.
+        self.required_config.add_option(
+            name=configman_name,
+            default=configman_default,
+            doc=configman_doc,
+            from_string_converter=configman_from_string,
+            to_string_converter=configman_to_string,
+            #short_form=configman_short_form,
+            is_argument=configman_is_argument,
+            not_for_definition=configman_not_for_definition,
+            # we're going to save the args & kwargs that created the
+            # argparse Action.  This enables us to perfectly reproduce the
+            # the original Action object later during the configman overlay
+            # process.
+            foreign_data=DotDict({
+                'argparse.flags.subcommand': False,
+                'argparse.args': args,
+                'argparse.kwargs': kwargs,
+                'argparse.owning_subparser_name': self.subparser_name,
+            })
+        )
+        return an_action
+
+    #--------------------------------------------------------------------------
+    def add_subparsers(self, *args, **kwargs):
+        """When adding a subparser, we need to ensure that our version of the
+        SubparserAction object is returned.  We also need to create the
+        corresponding configman Option object for the subparser and pack it's
+        foreign data section with the original args & kwargs."""
+
+        kwargs['parser_class'] = self.__class__
+        kwargs['action'] = ConfigmanSubParsersAction
+
+        subparser_action = super(ArgumentParser, self).add_subparsers(
+            *args,
+            **kwargs
+        )
+        self._argparse_subparsers = subparser_action
+
+        if "dest" not in kwargs or kwargs['dest'] is None:
+            kwargs['dest'] = 'subcommand'
+        configman_name = kwargs['dest']
+        configman_default = None
+        configman_doc = kwargs.get('help', '')
+        subprocessor_from_string_converter = SubparserFromStringConverter()
+        configman_to_string = str
+        configman_is_argument = True
+        configman_not_for_definition = True
+
+        # it's finally time to create the configman Option object and add it
+        # to the required_config.
+        self.required_config.add_option(
+            name=configman_name,
+            default=configman_default,
+            doc=configman_doc,
+            from_string_converter=subprocessor_from_string_converter,
+            to_string_converter=configman_to_string,
+            is_argument=configman_is_argument,
+            not_for_definition=configman_not_for_definition,
+            # we're going to save the input parameters that created the
+            # argparse Action.  This enables us to perfectly reproduce the
+            # the original Action object later during the configman overlay
+            # process.
+            foreign_data=DotDict({
+                'argparse.flags.subcommand': subparser_action,
+                'argparse.args': args,
+                'argparse.kwargs': kwargs,
+                'argparse.subparsers': DotDict(),
+                'argparse.subprocessor_from_string_converter':
+                subprocessor_from_string_converter
+            })
+        )
+
+        self.configman_subparsers_option = self.required_config[configman_name]
+        subparser_action.add_configman_option(self.configman_subparsers_option)
+
+        return subparser_action
+
+    #--------------------------------------------------------------------------
+    def set_defaults(self, **kwargs):
+        """completely take over the 'set_defaults' system of argparse, because
+        configman has no equivalent.  These will be added back to the configman
+        result at the very end."""
+        self.extra_defaults = kwargs
+
+    #--------------------------------------------------------------------------
+    def parse_args(self, args=None, namespace=None):
+        """this method hijacks the normal argparse Namespace generation,
+        shimming configman into the process. The return value will be a
+        configman DotDict rather than an argparse Namespace."""
+        # load the config_manager within the scope of the method that uses it
+        # so that we avoid circular references in the outer scope
+        from configman.config_manager import ConfigurationManager
+        configuration_manager = ConfigurationManager(
+            definition_source=[self.get_required_config()],
+            values_source_list=self.value_source_list,
+            argv_source=args,
+            app_name=self.prog,
+            app_version=self.version,
+            app_description=self.description,
+            use_auto_help=False,
+        )
+
+        # it is apparent a common idiom that commandline options may have
+        # embedded '-' characters in them.  Configman requires that option
+        # follow the Python Identifier rules.  Fortunately, Configman has a
+        # class that will perform dynamic translation of keys.  In this
+        # code fragment, we fetch the final configuration from configman
+        # using a Mapping that will translate keys with '-' into keys with
+        # '_' instead.
+        conf = configuration_manager.get_config(
+            mapping_class=create_key_translating_dot_dict(
+                "HyphenUnderscoreDict",
+                (('-', '_'),)
+            )
+        )
+
+        # here is where we add the values given to "set_defaults" method
+        # of argparse.
+        if self.configman_subparsers_option:
+            subparser_name = conf[self.configman_subparsers_option.name]
+            try:
+                conf.update(
+                    self.configman_subparsers_option.foreign_data.argparse
+                    .subparsers[subparser_name].subparser
+                    .extra_defaults
+                )
+            except (AttributeError, KeyError):
+                # no extra_defaults skip on
+                pass
+
+        if hasattr(self, 'extra_defaults'):
+            conf.update(self.extra_defaults)
+
+        return conf
+
+    #--------------------------------------------------------------------------
+    def parse_known_args(self, args=None, namespace=None):
+        """this method hijacks the normal argparse Namespace generation,
+        shimming configman into the process. The return value will be a
+        configman DotDict rather than an argparse Namespace."""
+        # load the config_manager within the scope of the method that uses it
+        # so that we avoid circular references in the outer scope
+        from configman.config_manager import ConfigurationManager
+        configuration_manager = ConfigurationManager(
+            definition_source=[self.get_required_config()],
+            values_source_list=self.value_source_list,
+            argv_source=args,
+            app_name=self.prog,
+            app_version=self.version,
+            app_description=self.description,
+            use_auto_help=False,
+        )
+        conf = configuration_manager.get_config(
+            mapping_class=create_key_translating_dot_dict(
+                "HyphenUnderscoreDict",
+                (('-', '_'),)
+            )
+        )
+        return conf
+
+
+#------------------------------------------------------------------------------
+def setup_definitions(source, destination):
+    """this method stars the process of configman reading and using an argparse
+    instance as a source of configuration definitions."""
+    #"""assume that source is of type argparse
+    try:
+        destination.update(source.get_required_config())
+    except AttributeError:
+        # looks like the user passed in a real arpgapse parser rather than our
+        # bastardized version of one.  No problem, we can work with it,
+        # though the translation won't be as perfect.
+        our_parser = ArgumentParser()
+        for i, an_action in enumerate(source._actions):
+            args, kwargs = get_args_and_values(source, an_action)
+            dest = kwargs.get('dest', '')
+            if dest in ('help', 'version'):
+                continue
+            our_parser.add_argument(*args, **kwargs)
+        destination.update(our_parser.get_required_config())

--- a/configman/option.py
+++ b/configman/option.py
@@ -35,6 +35,7 @@ class Option(object):
         reference_value_from=None,
         secret=False,
         has_changed=False,
+        foreign_data=None,
     ):
         self.name = name
         self.short_form = short_form
@@ -63,6 +64,7 @@ class Option(object):
         self.reference_value_from = reference_value_from
         self.secret = secret
         self.has_changed = has_changed
+        self.foreign_data = foreign_data
 
     #--------------------------------------------------------------------------
     def __str__(self):
@@ -97,7 +99,9 @@ class Option(object):
         if self.default is None:
             return '<Option: %r>' % self.name
         else:
-            return '<Option: %r, default=%r>' % (self.name, self.default)
+            return '<Option: %r, default=%r, value=%r, is_argument=%r>' % (
+                self.name, self.default, self.value, self.is_argument
+            )
 
     #--------------------------------------------------------------------------
     def _deduce_converter(self, default):
@@ -191,6 +195,7 @@ class Option(object):
             reference_value_from=self.reference_value_from,
             secret=self.secret,
             has_changed=self.has_changed,
+            foreign_data=self.foreign_data,
         )
         return o
 

--- a/configman/tests/test_config_files.py
+++ b/configman/tests/test_config_files.py
@@ -14,7 +14,7 @@ from configman.namespace import Namespace
 from configman.config_manager import ConfigurationManager
 from configman.config_file_future_proxy import ConfigFileFutureProxy
 
-from configman.command_line import command_line
+from configman import command_line
 
 
 #--------------------------------------------------------------------------

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -13,7 +13,12 @@ import getopt
 
 import mock
 
+import argparse
+import getopt
+
+
 import configman.config_manager as config_manager
+from configman.commandline import command_line
 from configman.option import Option
 from configman.dotdict import (
     DotDict,
@@ -21,6 +26,7 @@ from configman.dotdict import (
     create_key_translating_dot_dict,
 )
 from configman import Namespace, RequiredConfig
+from configman.config_file_future_proxy import ConfigFileFutureProxy
 from configman.converters import class_converter
 from configman.datetime_util import datetime_from_ISO_string
 from configman.config_exceptions import NotAnOptionError
@@ -770,14 +776,13 @@ c.string =   from ini
             [n],
             use_admin_controls=True,
             use_auto_help=False,
-            argv_source=[],
+            argv_source=['some_app'],
         )
         s = StringIO()
         c.output_summary(output_stream=s)
         r = s.getvalue()
-        self.assertTrue('OPTIONS:\n' in r)
+        self.assertTrue('[OPTIONS]... ' in r)
         self.assertTrue('application' in r)  # yeah, we want to see option
-        self.assertFalse('[ application' in r)  # but don't want it optional
 
     #--------------------------------------------------------------------------
     def test_output_summary_with_argument_2(self):
@@ -2104,7 +2109,8 @@ c.string =   from ini
 
         cm = config_manager.ConfigurationManager(
             (n,),
-            argv_source=[]
+            values_source_list=[ConfigFileFutureProxy, getopt],
+            argv_source=[],
         )
         opts = cm.get_option_names()
         for an_opt in opts:

--- a/configman/tests/test_def_for_argparse.py
+++ b/configman/tests/test_def_for_argparse.py
@@ -1,0 +1,482 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittest import TestCase
+from mock import patch
+
+
+from StringIO import StringIO
+
+try:
+    import argparse
+except ImportError:
+    try:
+        from unittest import SkipTest
+    except ImportError:
+        from nose.plugins.skip import SkipTest
+    raise SkipTest
+
+from configman import ArgumentParser
+from configman.dotdict import DotDict
+
+expected_value = {
+    "test_expansion_subparsers_1":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+
+positional arguments:
+  {a,b}                 sub-command help
+    a                   a help
+    b                   b help
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --foo                 foo help
+  --egg EGG             eggs
+""",
+
+    "test_expansion_subparsers_2":
+"""usage: highwater a [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--fff FFF]
+                   bar
+
+positional arguments:
+  bar                   bar help
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --fff FFF             a fff help
+""",
+    "test_expansion_subparsers_3":
+"""usage: highwater b [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--baz {X,Y,Z}] [--fff {X,Y,Z}]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --baz {X,Y,Z}         baz help
+  --fff {X,Y,Z}         b fff help
+""",
+    "test_expansion_subparsers_4":
+"""usage: highwater [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: argument sub_command: invalid choice: 'c' (choose from 'a', 'b')
+""",
+    "test_expansion_subparsers_5":
+"""usage: highwater a [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--fff FFF]
+                   bar
+highwater a: error: too few arguments
+""",
+    "test_expansion_subparsers_6":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: unrecognized arguments: --baz Y
+""",
+    "test_expansion_subparsers_7":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: unrecognized arguments: 16
+""",
+    "test_expansion_subparsers_defaults_values_1":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'a',
+        'bar': 16,
+        'fff': None,
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+    "test_expansion_subparsers_defaults_values_2":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'a',
+        'bar': 16,
+        'fff': 9,
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+    "test_expansion_subparsers_defaults_values_3":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'b',
+        'baz': None,
+        'fff': 'X',
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+}
+
+
+#==============================================================================
+class TestCaseForDefSourceArgparse(TestCase):
+
+    #--------------------------------------------------------------------------
+    def setup_argparse(self):
+        parser = ArgumentParser(prog='hell')
+        parser.add_argument(
+            '-s',
+            action='store',
+            dest='simple_value',
+            help='Store a simple value'
+        )
+        parser.add_argument(
+            '--missing_from_help',
+            action='store',
+            dest='missing_from_help',
+            help='should not be seen in help',
+            suppress_help=True,
+        )
+        parser.add_argument(
+            '-c',
+            action='store_const',
+            dest='constant_value',
+            const='value-to-store',
+            help='Store a constant value'
+        )
+        parser.add_argument(
+            '-t',
+            action='store_true',
+            default=False,
+            dest='boolean_switch',
+            help='Set a switch to true'
+        )
+        parser.add_argument(
+            '-f',
+            action='store_false',
+            default=False,
+            dest='boolean_switch',
+            help='Set a switch to false'
+        )
+        parser.add_argument(
+            '-a',
+            action='append',
+            dest='collection',
+            default=[],
+            help='Add repeated values to a list',
+        )
+        parser.add_argument(
+            '-A',
+            action='append_const',
+            dest='const_collection',
+            const='value-1-to-append',
+            default=[],
+            help='Add different values to list'
+        )
+        parser.add_argument(
+            '-B',
+            action='append_const',
+            dest='const_collection',
+            const='value-2-to-append',
+            help='Add different values to list'
+        )
+        parser.add_argument(
+            '--version',
+            action='version',
+            version='%(prog)s 1.0'
+        )
+        return parser
+
+    #--------------------------------------------------------------------------
+    def test_parser_setup(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=[])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_1(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-s', '3', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, '3')
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_2(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-c', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, 'value-to-store')
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_3(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-t', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, True)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_4(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-f', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_5(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-a', '1'])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, ['1'])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_6(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-a', '1', '-a', '2'])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, ['1', '2'])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_7(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-A', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, ['value-1-to-append'])
+
+    #--------------------------------------------------------------------------
+    def test_parser_8(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-B', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, ['value-2-to-append'])
+
+    #--------------------------------------------------------------------------
+    def test_parser_9(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-A', '-B'])
+
+        #self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(
+            config.const_collection,
+            ['value-1-to-append', 'value-2-to-append']
+        )
+
+    #--------------------------------------------------------------------------
+    def test_parser_10(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=[
+            '-A', '-B', '-a', '1', '-s', 'a', '-c', '-t', '-a', '2',
+        ])
+
+        self.assertEqual(config.simple_value, 'a')
+        self.assertEqual(config.constant_value, 'value-to-store')
+        self.assertEqual(config.boolean_switch, True)
+        self.assertEqual(config.collection, ['1', '2'])
+        self.assertEqual(
+            config.const_collection,
+            ['value-1-to-append', 'value-2-to-append']
+        )
+
+    #--------------------------------------------------------------------------
+    def setup_subparser(self):
+        parser = ArgumentParser(prog='highwater')
+        parser.add_argument('--foo', action='store_true', help='foo help', dest='foo')
+        parser.add_argument('--egg', action='store', help='eggs', type=str)
+        subparsers = parser.add_subparsers(help='sub-command help', dest='sub_command')
+        parser_a = subparsers.add_parser('a', help='a help')
+        parser_a.add_argument('bar', type=int, help='bar help')
+        parser_a.add_argument('--fff', type=int, help='a fff help')
+        parser_b = subparsers.add_parser('b', help='b help')
+        parser_b.add_argument('--baz', choices='XYZ', help='baz help')
+        parser_b.add_argument('--fff', choices='XYZ', help='b fff help')
+
+        return parser
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stdout', new_callable=StringIO)
+    def impl_for_subparser_stdout_with_exit(self, args, expected, mock_stdout):
+        parser = self.setup_subparser()
+        self.assertRaises(
+            SystemExit,
+            parser.parse_args,
+            args
+        )
+        x = mock_stdout.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stdout', new_callable=StringIO)
+    def impl_for_subparser_stdout(self, args, expected, mock_stdout):
+        parser = self.setup_subparser()
+        parser.parse_args(args=args)
+        x = mock_stdout.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stderr', new_callable=StringIO)
+    def impl_for_subparser_stderr_with_exit(self, args, expected, mock_stderr):
+        parser = self.setup_subparser()
+        self.assertRaises(
+            SystemExit,
+            parser.parse_args,
+            args
+        )
+        x = mock_stderr.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stderr', new_callable=StringIO)
+    def impl_for_subparser_stderr(self, args, expected, mock_stderr):
+        parser = self.setup_subparser()
+        parser.parse_args(args=args)
+        x = mock_stderr.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_stdout_with_exit(self):
+        tests = (
+            (['--help'], expected_value['test_expansion_subparsers_1']),
+            (['a', '--help'], expected_value['test_expansion_subparsers_2']),
+            (['b', '--help'], expected_value['test_expansion_subparsers_3']),
+        )
+        for args, expected in tests:
+            self.impl_for_subparser_stdout_with_exit(args, expected)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_stderr_with_exit(self):
+        tests = (
+            (['c'], expected_value['test_expansion_subparsers_4']),
+            (['a', '-fff'], expected_value['test_expansion_subparsers_5']),
+            (['a', '16', '--fff', '21', '--baz', 'Y'], expected_value['test_expansion_subparsers_6']),
+            (['b', '16', '--fff', 'X'], expected_value['test_expansion_subparsers_7']),
+        )
+        for args, expected in tests:
+            self.impl_for_subparser_stderr_with_exit(args, expected)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_values(self):
+        tests = (
+            (['a', '16'], expected_value['test_expansion_subparsers_defaults_values_1']),
+            (['a', '16', '--fff=9'], expected_value['test_expansion_subparsers_defaults_values_2']),
+            (['a', '16', '--fff', '9'], expected_value['test_expansion_subparsers_defaults_values_2']),
+            (['b', '--fff', 'X'], expected_value['test_expansion_subparsers_defaults_values_3']),
+        )
+        parser = self.setup_subparser()
+        for args, expected in tests:
+            result = parser.parse_args(args=args)
+            self.assertEqual(dict(result), dict(expected), '%s failed' % args)

--- a/configman/tests/test_val_for_argparse.py
+++ b/configman/tests/test_val_for_argparse.py
@@ -1,0 +1,397 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittest import TestCase
+
+try:
+    import argparse
+except ImportError:
+    try:
+        from unittest import SkipTest
+    except ImportError:
+        from nose.plugins.skip import SkipTest
+    raise SkipTest
+
+from mock import Mock
+from os import environ
+
+from functools import partial
+
+from configman import Namespace, ConfigurationManager
+from configman.converters import (
+    class_converter,
+    boolean_converter,
+    list_converter,
+    list_to_str,
+    to_str,
+)
+
+from configman.config_file_future_proxy import ConfigFileFutureProxy
+from configman.commandline import command_line
+from configman.dotdict import DotDict
+from configman.value_sources.source_exceptions import CantHandleTypeException
+
+from configman.def_sources.for_argparse import ArgumentParser
+from configman.value_sources.for_argparse import (
+    #issubclass_with_no_type_error,
+    ValueSource,
+    argparse,
+    IntermediateConfigmanParser,
+)
+
+#------------------------------------------------------------------------------
+def quote_stripping_list_of_ints(a_string):
+    quoteless = a_string.strip('\'"')
+    return list_converter(
+        quoteless,
+        item_separator=' ',
+        item_converter=int
+    )
+
+#==============================================================================
+class TestCaseForValSourceArgparse(TestCase):
+
+    #--------------------------------------------------------------------------
+    def setup_value_source(self, type_of_value_source=ValueSource):
+        conf_manager = Mock()
+        conf_manager.argv_source = []
+
+        arg = ArgumentParser()
+        arg.add_argument(
+            '--wilma',
+            dest='wilma',
+        )
+        arg.add_argument(
+            dest='dwight',
+            nargs='*',
+            type=int
+        )
+        vs = type_of_value_source(arg, conf_manager)
+        return vs
+
+    #--------------------------------------------------------------------------
+    def setup_configman_namespace(self):
+        n = Namespace()
+        n.add_option(
+            'alpha',
+            default=3,
+            doc='the first parameter',
+            is_argument=True
+        )
+        n.add_option(
+            'beta',
+            default='the second',
+            doc='the first parameter',
+            short_form = 'b',
+        )
+        n.add_option(
+            'gamma',
+            default="1 2 3",
+            from_string_converter=quote_stripping_list_of_ints,
+            to_string_converter=partial(
+                list_to_str,
+                delimiter=' '
+            ),
+            secret=True,
+        )
+        n.add_option(
+            'delta',
+            default=False,
+            from_string_converter=boolean_converter
+        )
+        return n
+
+    #--------------------------------------------------------------------------
+    def test_basic_01_defaults(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 3,
+            "beta": "the second",
+            "gamma": [1, 2, 3],
+            "delta": False,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": False
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_02_change_all(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[
+                "16",
+                "-b=THE SECOND",
+                '--gamma="88 99 111 333"',
+                "--delta",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 16,
+            "beta": 'THE SECOND',
+            "gamma": [88, 99, 111, 333],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": False
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_02_change_all(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[
+                "16",
+                "--b=THE SECOND",
+                '--gamma="88 99 111 333"',
+                "--delta",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 16,
+            "beta": 'THE SECOND',
+            "gamma": [88, 99, 111, 333],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": False
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_03_with_some_admin(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                '--gamma="-1 -2 -3 -4 -5 -6"',
+                "--delta",
+                "--admin.strict",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [-1, -2, -3, -4, -5, -6],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_04_argparse_doesnt_dominate(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [38, 28, 18, 8],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_05_argparse_overrides_when_appropriate(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+                '--gamma="8 18 28 38"',
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+
+    #--------------------------------------------------------------------------
+    def test_basic_06_argparse_class_expansion(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        other_definition_source = Namespace()
+        other_definition_source.add_option(
+            "a_class",
+            default="configman.tests.test_val_for_modules.Alpha",
+            from_string_converter=class_converter
+        )
+        cm = ConfigurationManager(
+            definition_source=[option_definitions, other_definition_source],
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+                '--gamma="8 18 28 38"',
+                '--a_class=configman.tests.test_val_for_modules.Beta'
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True,
+            "a_class": class_converter(
+                "configman.tests.test_val_for_modules.Beta"
+            ),
+            "b": 23
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_07_argparse_multilevel_class_expansion(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        other_definition_source = Namespace()
+        other_definition_source.add_option(
+            "a_class",
+            default="configman.tests.test_val_for_modules.Alpha",
+            from_string_converter=class_converter
+        )
+        cm = ConfigurationManager(
+            definition_source=[option_definitions, other_definition_source],
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                '--gamma="8 18 28 38"',
+                '--a_class=configman.tests.test_val_for_modules.Delta',
+                '--messy=34'
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": True,
+            "a_class": class_converter(
+                "configman.tests.test_val_for_modules.Delta"
+            ),
+            "messy": 34,
+            "dd": class_converter(
+                "configman.tests.test_val_for_modules.Beta"
+            ),
+            'b': 23,
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/configman/tests/test_val_for_argparse.py
+++ b/configman/tests/test_val_for_argparse.py
@@ -14,7 +14,6 @@ except ImportError:
     raise SkipTest
 
 from mock import Mock
-from os import environ
 
 from functools import partial
 
@@ -24,21 +23,16 @@ from configman.converters import (
     boolean_converter,
     list_converter,
     list_to_str,
-    to_str,
 )
 
-from configman.config_file_future_proxy import ConfigFileFutureProxy
 from configman.commandline import command_line
-from configman.dotdict import DotDict
-from configman.value_sources.source_exceptions import CantHandleTypeException
 
 from configman.def_sources.for_argparse import ArgumentParser
 from configman.value_sources.for_argparse import (
     #issubclass_with_no_type_error,
     ValueSource,
-    argparse,
-    IntermediateConfigmanParser,
 )
+
 
 #------------------------------------------------------------------------------
 def quote_stripping_list_of_ints(a_string):
@@ -48,6 +42,7 @@ def quote_stripping_list_of_ints(a_string):
         item_separator=' ',
         item_converter=int
     )
+
 
 #==============================================================================
 class TestCaseForValSourceArgparse(TestCase):
@@ -83,7 +78,7 @@ class TestCaseForValSourceArgparse(TestCase):
             'beta',
             default='the second',
             doc='the first parameter',
-            short_form = 'b',
+            short_form='b',
         )
         n.add_option(
             'gamma',
@@ -136,36 +131,6 @@ class TestCaseForValSourceArgparse(TestCase):
             argv_source=[
                 "16",
                 "-b=THE SECOND",
-                '--gamma="88 99 111 333"',
-                "--delta",
-            ],
-            use_auto_help=False,
-        )
-        config = cm.get_config()
-
-        expected = {
-            "alpha": 16,
-            "beta": 'THE SECOND',
-            "gamma": [88, 99, 111, 333],
-            "delta": True,
-            "admin.print_conf": None,
-            "admin.dump_conf": '',
-            "admin.strict": False,
-            "admin.expose_secrets": False
-        }
-
-        for k in config.keys_breadth_first():
-            self.assertEqual(config[k], expected[k])
-
-    #--------------------------------------------------------------------------
-    def test_basic_02_change_all(self):
-        option_definitions = self.setup_configman_namespace()
-        cm = ConfigurationManager(
-            definition_source=option_definitions,
-            values_source_list=[command_line],
-            argv_source=[
-                "16",
-                "--b=THE SECOND",
                 '--gamma="88 99 111 333"',
                 "--delta",
             ],
@@ -285,7 +250,6 @@ class TestCaseForValSourceArgparse(TestCase):
         for k in config.keys_breadth_first():
             self.assertEqual(config[k], expected[k])
 
-
     #--------------------------------------------------------------------------
     def test_basic_06_argparse_class_expansion(self):
         option_definitions = self.setup_configman_namespace()
@@ -379,19 +343,3 @@ class TestCaseForValSourceArgparse(TestCase):
 
         for k in config.keys_breadth_first():
             self.assertEqual(config[k], expected[k])
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/configman/tests/test_val_for_modules.py
+++ b/configman/tests/test_val_for_modules.py
@@ -20,6 +20,7 @@ from configman import (
 from configman.option import Option
 from configman.config_exceptions import CannotConvertError, NotAnOptionError
 from configman.value_sources.for_modules import ValueSource
+from configman.converters import class_converter
 
 
 #==============================================================================
@@ -47,6 +48,20 @@ class Beta(RequiredConfig):
         self.config = config
         self.b = config.b
 
+#==============================================================================
+class Delta(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+        'messy',
+        doc='messy',
+        default=-99
+    )
+    required_config.add_option(
+        'dd',
+        doc='dd',
+        default=Beta,
+        from_string_converter=class_converter
+    )
 
 #==========================================================================
 class TestCase(unittest.TestCase):

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -20,7 +20,7 @@ from configman.config_file_future_proxy import ConfigFileFutureProxy
 from configman.config_exceptions import CannotConvertError
 
 # replace with dynamic discovery and loading
-#from configman.value_sources import for_argparse
+from configman.value_sources import for_argparse
 #from configman.value_sources import or_xml
 from configman.value_sources import for_getopt
 from configman.value_sources import for_json
@@ -31,6 +31,7 @@ from configman.value_sources import for_modules
 
 # please replace with dynamic discovery
 for_handlers = [
+    for_argparse,
     for_mapping,
     for_getopt,
     for_json,

--- a/configman/value_sources/for_argparse.py
+++ b/configman/value_sources/for_argparse.py
@@ -1,0 +1,579 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module implements a configuration value source from the commandline
+implemented using argparse.  This was a difficult module to make because of
+some fundemental differences with the way that configman and argparse set up
+their respective priorities.
+
+One of the primary problems is that both configman and argparse have their own
+data definition specs.  Configman has Options while argparse has Actions.  Both
+libraries can use their own specs, so a translation layer had to be created.
+
+During the process of configman's overlay/expansion phase, the definitions as
+to what is allowed on the command line change. What was not allowed during an
+earlier pass may be allowed in a later pass.  This means that argparse may need
+to be setup and used several times as the definitions change.
+
+Creating a perfect round trip translation system proved to be impossible
+because the feature sets of argparse and configman do not correspond pefectly.
+So rather than trying to translate everything, each phase of the original
+argparse definitions (args & kwargs) are captured and stored.  Then when
+configman needs to get command line parameters during the overlay/expansion
+process, it is able to perfectly recreate the original arparse parsers tweaked
+with whatever new arguments that the expansion process introduced.
+
+This module introduces a flock of different derivations of argparse parsers.
+Each is used in a different context during the overlay expansion process.
+While several of them are functionally equivalent, we keep them as separate
+classes so that we can use class identity as a differention mechanism.
+"""
+
+import argparse
+import copy
+
+import collections
+
+from configman.option import Option
+from configman.dotdict import DotDict
+from configman.converters import (
+    boolean_converter,
+    to_str,
+)
+from configman.namespace import Namespace
+
+is_command_line_parser = True
+
+can_handle = (
+    argparse,
+)
+
+parser_count = 0
+
+
+#==============================================================================
+class IntermediateConfigmanParser(argparse.ArgumentParser):
+    """"""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        self.subparser_name = kwargs.pop('subparser_name', None)
+        self.configman_subparsers_option = kwargs.pop(
+            'configman_subparsers_option',
+            None
+        )
+        super(IntermediateConfigmanParser, self).__init__(
+            *args, **kwargs
+        )
+        self.required_config = Namespace()
+
+        self._use_argparse_add_help = kwargs.get('add_help', False)
+
+    #--------------------------------------------------------------------------
+    def get_parser_id(self):
+        global parser_count
+        if hasattr(self, 'id'):
+            return
+        self.id = "%03d" % parser_count
+        parser_count += 1
+
+    #--------------------------------------------------------------------------
+    def error(self, message):
+        """we need to suppress errors that might happen in earlier phases of
+        the expansion/overlay process. """
+        if (
+            "not allowed" in message
+            or "ignored" in message
+            or "expected" in message
+            or "invalid" in message
+            or self.add_help
+        ):
+            # when we have "help" then we must also have proper error
+            # processing.  Without "help", we suppress the errors by
+            # doing nothing here
+            super(IntermediateConfigmanParser, self).error(message)
+
+    #--------------------------------------------------------------------------
+    def parse_args(self, args=None, namespace=None, object_hook=None):
+        proposed_config = \
+            super(IntermediateConfigmanParser, self).parse_args(
+                args,
+                namespace
+            )
+        return proposed_config
+
+    #--------------------------------------------------------------------------
+    def parse_known_args(self, args=None, namespace=None, object_hook=None):
+        result = super(IntermediateConfigmanParser, self) \
+            .parse_known_args(args, namespace)
+        try:
+            an_argparse_namespace, extra_arguments = result
+        except TypeError:
+            an_argparse_namespace = argparse.Namespace()
+            extra_arguments = result
+        return (an_argparse_namespace, extra_arguments)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def argparse_namespace_to_dotdict(proposed_config, object_hook=None):
+        if object_hook is None:
+            object_hook = DotDict
+        config = object_hook()
+        for key, value in proposed_config.__dict__.iteritems():
+            config[key] = value
+        return config
+
+counter = 0
+
+
+#==============================================================================
+class FinalStageConfigmanParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        super(FinalStageConfigmanParser, self).__init__(
+            *args, **kwargs
+        )
+
+
+#==============================================================================
+class HelplessConfigmanParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        self.get_parser_id()
+        super(HelplessConfigmanParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class IntermediateConfigmanSubParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        super(IntermediateConfigmanSubParser, self).__init__(
+            *args, **kwargs
+        )
+
+
+#==============================================================================
+class HelplessIntermediateConfigmanSubParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        self.get_parser_id()
+        super(HelplessIntermediateConfigmanSubParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class ConfigmanAdminParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = True
+        #new_kwargs['add_help'] = False
+        new_kwargs['prog'] = 'admin%s' % self.id
+        new_kwargs['parents'] = []
+        super(ConfigmanAdminParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class HelplessConfigmanAdminParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        new_kwargs['prog'] = 'admin%s' % self.id
+        new_kwargs['parents'] = []
+        super(HelplessConfigmanAdminParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class ParserContainer(object):
+    """this class is a argparse ArgumentParser generator.  Configman uses
+    it to create sets of linked ArgumentParsers of the appropriate types.  It
+    does the translations between configman and argparse.  First it tries to
+    create argparse parameters by fetch original args & kwargs from the
+    foreign_data sections of the configman Options.  Failing that, it tries
+    to translate configman Options as best as it can."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+
+        self.main_parser_args = DotDict()
+        self.main_parser_args.args = args
+        self.main_parser_args.kwargs = kwargs.copy()
+        self.main_parser_args.kwargs.setdefault('parents', [])
+        self.arguments_for_building_argparse = []
+        self.subcommand = None
+        self.subparser_args_list = []
+        self.subparsers = {}
+        self.admin_parser_args = DotDict()
+        self.admin_parser_args.args = args
+        self.admin_parser_args.kwargs = kwargs.copy()
+        self.admin_arguments = []
+        self._use_argparse_add_help = kwargs.get('add_help', False)
+        self.get_parser_id()
+        self.extra_defaults = {}
+
+    #--------------------------------------------------------------------------
+    def get_parser_id(self):
+        global parser_count
+        if hasattr(self, 'id'):
+            return
+        self.id = "%03d" % parser_count
+        parser_count += 1
+
+    #--------------------------------------------------------------------------
+    def create_argparse_parser(
+        self,
+        main_parser_class=HelplessConfigmanParser,
+        subparser_class=IntermediateConfigmanSubParser,
+        admin_parser_class=ConfigmanAdminParser,
+    ):
+        # create admin parser to be used a a parent parser
+        self.admin_parser_args.kwargs['parents'] = []
+        admin_parser = admin_parser_class(
+            *self.admin_parser_args.args,
+            **self.admin_parser_args.kwargs
+        )
+
+        for admin_args in self.admin_arguments:
+            admin_args.kwargs['default'] = argparse.SUPPRESS
+            admin_parser.add_argument(*admin_args.args, **admin_args.kwargs)
+
+        # create the main parser
+        self.main_parser_args.kwargs['parents'] = [admin_parser]
+        main_parser = main_parser_class(
+            *self.main_parser_args.args,
+            **self.main_parser_args.kwargs
+        )
+
+        if self.subcommand is not None:
+            # add any subparsers to the parent parser
+            subcommand_kwargs = copy.copy(self.subcommand.kwargs)
+            subcommand_kwargs['parser_class'] = subparser_class
+            subcommand_kwargs.setdefault('parents', [])
+            if 'parents' in subcommand_kwargs:
+                del subcommand_kwargs['parents']
+            if 'action' in subcommand_kwargs:
+                del subcommand_kwargs['action']
+            local_subparser_action = main_parser.add_subparsers(
+                *self.subcommand.args,
+                **subcommand_kwargs
+            )
+            local_subparser_action.default = argparse.SUPPRESS
+            for subparser_name in self.subcommand.subparsers.keys():
+                subparser_kwargs = copy.copy(
+                    self.subcommand.subparsers[subparser_name].kwargs
+                )
+                subparser_args = \
+                    self.subcommand.subparsers[subparser_name].args
+                if 'dest' in subparser_kwargs:
+                    del subparser_kwargs['dest']
+                subparser_kwargs['parents'] = [admin_parser]
+                local_subparser = local_subparser_action.add_parser(
+                    *subparser_args,
+                    **subparser_kwargs
+                )
+                self.subparsers[subparser_name] = local_subparser
+
+        # add the actual arguments to the appropriate main or subparsers
+        for args_for_an_argparse_argument in (
+            self.arguments_for_building_argparse
+        ):
+            args = args_for_an_argparse_argument.args
+            kwargs = args_for_an_argparse_argument.kwargs
+            owning_subparser_name = args_for_an_argparse_argument.get(
+                'owning_subparser_name',
+                None
+            )
+            if owning_subparser_name:
+                the_parser = self.subparsers[owning_subparser_name]
+                the_parser.add_argument(*args, **kwargs)
+            else:
+                main_parser.add_argument(*args, **kwargs)
+
+        return main_parser
+
+    #--------------------------------------------------------------------------
+    def _add_argument_from_original_source(self, qualified_name, option):
+        argparse_foreign_data = option.foreign_data.argparse
+        if argparse_foreign_data.flags.subcommand:
+            # this argument represents a subcommand, we must setup the
+            # subparsers
+            self.subcommand = argparse_foreign_data
+            self.subparser_orignal_args = argparse_foreign_data.subparsers
+            self.subcommand_configman_option = option
+
+        else:
+            new_arguments = DotDict()
+            new_arguments.args = argparse_foreign_data.args
+            new_arguments.kwargs = copy.copy(argparse_foreign_data.kwargs)
+            new_arguments.qualified_name = qualified_name
+            new_arguments.owning_subparser_name = \
+                argparse_foreign_data.owning_subparser_name
+
+            if new_arguments.args == (qualified_name.split('.')[-1],):
+                new_arguments.args = (qualified_name,)
+            elif 'dest' in new_arguments.kwargs:
+                if new_arguments.kwargs['dest'] != qualified_name:
+                    new_arguments.kwargs['dest'] = qualified_name
+            else:
+                new_arguments.kwargs['dest'] = qualified_name
+            try:
+                new_arguments.kwargs['dest'] = \
+                    new_arguments.kwargs['dest'].replace('$', '')
+            except KeyError:
+                # there was no 'dest' key, so we can ignore this error
+                pass
+            self.arguments_for_building_argparse.append(new_arguments)
+
+    #--------------------------------------------------------------------------
+    def _add_argument_from_configman_option(self, qualified_name, option):
+        opt_name = qualified_name
+        kwargs = DotDict()
+
+        if option.is_argument:  # is positional argument
+            option_name = opt_name
+        else:
+            option_name = '--%s' % opt_name
+            kwargs.dest = opt_name
+
+        if option.short_form:
+            option_short_form = '-%s' % option.short_form
+            args = (option_name, option_short_form)
+        else:
+            args = (option_name,)
+
+        if option.from_string_converter in (bool, boolean_converter):
+            kwargs.action = 'store_true'
+        else:
+            kwargs.action = 'store'
+
+        kwargs.default = argparse.SUPPRESS
+        kwargs.help = option.doc
+
+        new_arguments = DotDict()
+        new_arguments.args = args
+        new_arguments.kwargs = kwargs
+        new_arguments.qualified_name = qualified_name
+
+        if (
+            isinstance(option.default, collections.Sequence)
+            and not isinstance(option.default, basestring)
+        ):
+            if option.is_argument:
+                kwargs.nargs = len(option.default)
+            else:
+                kwargs.nargs = "+"
+
+        if qualified_name.startswith('admin'):
+            self.admin_arguments.append(new_arguments)
+        else:
+            self.arguments_for_building_argparse.append(new_arguments)
+
+    #--------------------------------------------------------------------------
+    def add_argument_from_option(self, qualified_name, option):
+        if (
+            option.foreign_data is not None
+            and "argparse" in option.foreign_data
+        ):
+            self._add_argument_from_original_source(qualified_name, option)
+        else:
+            self._add_argument_from_configman_option(qualified_name, option)
+
+
+#==============================================================================
+class ValueSource(object):
+    """The ValueSource implementation for the argparse module.  This class will
+    interpret an argv list of commandline arguments using argparse returning
+    a DotDict derivative respresenting the values return by argparse."""
+    #--------------------------------------------------------------------------
+    def __init__(self, source, conf_manager):
+        self.source = source
+        self.parent_parsers = []
+        self.argv_source = tuple(conf_manager.argv_source)
+
+    # frequently, command line data sources must be treated differently.  For
+    # example, even when the overall option for configman is to allow
+    # non-strict option matching, the command line should not arbitrarily
+    # accept bad command line switches.  The existance of this key will make
+    # sure that a bad command line switch will result in an error without
+    # regard to the overall --admin.strict setting.
+    command_line_value_source = True
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _get_known_args(conf_manager):
+        return set(
+            x
+            for x in conf_manager.option_definitions.keys_breadth_first()
+        )
+
+    #--------------------------------------------------------------------------
+    def _option_to_args_list(self, an_option, key):
+        if an_option.is_argument:
+            if an_option.foreign_data is not None:
+                nargs = an_option.foreign_data.argparse.kwargs.get(
+                    'nargs',
+                    None
+                )
+            else:
+                if isinstance(an_option.value, basestring):
+                    return an_option.value
+                if an_option.to_string_converter:
+                    return an_option.to_string_converter(an_option.value)
+                return to_str(an_option.value)
+            if (
+                nargs is not None
+                and isinstance(an_option.value, collections.Sequence)
+            ):
+                if isinstance(an_option.value, basestring):
+                    return an_option.value
+                return [to_str(x) for x in an_option.value]
+            if an_option.value is None:
+                return []
+            return to_str(an_option.value)
+        #if an_option.foreign_data.argparse.kwargs.nargs == 0:
+            #return None
+        if an_option.from_string_converter in (bool, boolean_converter):
+            if an_option.value:
+                return "--%s" % key
+            return None
+        if an_option.value is None:
+            return None
+        return '--%s="%s"' % (
+            key,
+            to_str(an_option)
+        )
+
+    #--------------------------------------------------------------------------
+    def create_fake_args(self, config_manager):
+        # all of this is to keep argparse from barfing if the minumum number
+        # of required arguments is not in place at run time.  It may be that
+        # some config file or environment will bring them in later.   argparse
+        # needs to cope using this placebo argv
+        args = [
+            self._option_to_args_list(
+                config_manager.option_definitions[key],
+                key
+            )
+            for key in config_manager.option_definitions.keys_breadth_first()
+            if (
+                isinstance(
+                    config_manager.option_definitions[key],
+                    Option
+                )
+                and config_manager.option_definitions[key].is_argument
+            )
+        ]
+
+        flattened_arg_list = []
+        for x in args:
+            if isinstance(x, list):
+                flattened_arg_list.extend(x)
+            else:
+                flattened_arg_list.append(x)
+        final_arg_list = [
+            x.strip()
+            for x in flattened_arg_list
+            if x is not None and x.strip() != ''
+        ]
+        try:
+            return final_arg_list + self.extra_args
+        except (AttributeError, TypeError):
+            return final_arg_list
+
+    #--------------------------------------------------------------------------
+    def get_values(self, config_manager, ignore_mismatches, object_hook=None):
+        if ignore_mismatches:
+            self.extra_args = []
+            parser = self._create_new_argparse_instance(
+                {
+                    "main_parser_class": HelplessConfigmanParser,
+                    "subparser_class": HelplessIntermediateConfigmanSubParser,
+                    "admin_parser_class": HelplessConfigmanAdminParser
+                },
+                config_manager,
+                False,  # create auto help
+            )
+            namespace_and_extra_args = parser.parse_known_args(
+                args=self.argv_source
+            )
+
+            try:
+                argparse_namespace, unused_args = namespace_and_extra_args
+                self.extra_args.extend(unused_args)
+            except TypeError:
+                argparse_namespace = argparse.Namespace()
+                self.extra_args.extend(namespace_and_extra_args)
+
+        else:
+            fake_args = self.create_fake_args(config_manager)
+            if (
+                ('--help' in self.argv_source or "-h" in self.argv_source)
+                and '--help' not in fake_args and '-h' not in fake_args
+            ):
+                fake_args.append("--help")
+
+            parser = self._create_new_argparse_instance(
+                {
+                    "main_parser_class": FinalStageConfigmanParser,
+                    "subparser_class": IntermediateConfigmanSubParser,
+                    "admin_parser_class": HelplessConfigmanAdminParser
+                },
+                config_manager,
+                True,  # create Help
+            )
+
+            argparse_namespace = parser.parse_args(
+                args=fake_args,
+            )
+        return parser.argparse_namespace_to_dotdict(
+            argparse_namespace,
+            object_hook,
+        )
+
+    #--------------------------------------------------------------------------
+    def _create_new_argparse_instance(
+        self,
+        parser_classes,
+        config_manager,
+        create_auto_help,
+    ):
+        a_parser = ParserContainer(
+            prog=config_manager.app_name,
+            #version=config_manager.app_version,
+            description=config_manager.app_description,
+            add_help=create_auto_help,
+        )
+        self._setup_argparse(a_parser, parser_classes, config_manager)
+        main_parser = a_parser.create_argparse_parser(**parser_classes)
+        return main_parser
+
+    #--------------------------------------------------------------------------
+    def _setup_argparse(self, parser, parser_classes, config_manager):
+        # need to ensure that admin options are added first, since they'll
+        # go into a subparser and the subparser must be complete before
+        # given to any other parser as a parent
+        for opt_name in config_manager.option_definitions.keys_breadth_first():
+            an_option = config_manager.option_definitions[opt_name]
+            if isinstance(an_option, Option):
+                parser.add_argument_from_option(opt_name, an_option)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _setup_auto_help(the_config_manager):
+        pass  # there's nothing to do, argparse already has a help feature

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -241,3 +241,13 @@ class ValueSource(object):
                 # this option definition does have the concept of being
                 # an argument - likely an aggregation
                 pass
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _setup_auto_help(the_config_manager):
+        help_option = option.Option(
+            name='help',
+            doc='print this',
+            default=False
+        )
+        the_config_manager.definition_source_list.append({'help': help_option})

--- a/demo/advanced_demo1.py
+++ b/demo/advanced_demo1.py
@@ -41,7 +41,6 @@ def define_config():
       name='host',
       default='localhost',
       doc='the hostname of the database',
-      short_form='h'
     )
     definition.add_option(
       name='dbname',


### PR DESCRIPTION
big change, not sure how to make it smaller as the changes are comprehensive.

This makes configman a drop in replacement for argparse (including support for subparsers), but giving argparse all the "--admin..." stuff including config files (.conf, .ini, .json, .py), environment vars, etc.  

I would love to see this tried with some known python programs just to see how well (or badly) it works.  

``` python
from configman import ArgumentParser
parser = ArgumentParser(prog='my_app')
parser.add_argument('--foo', action='store_true', help='foo help', dest='foo')
parser.add_argument('--egg', action='store', help='eggs', type=str)
subparsers = parser.add_subparsers(help='sub-command help', dest='sub_command')
parser_a = subparsers.add_parser('a', help='a help')
parser_a.add_argument('bar', type=int, help='bar help')
parser_a.add_argument('--fff', type=int, help='a fff help')
parser_b = subparsers.add_parser('b', help='b help')
parser_b.add_argument('--baz', choices='XYZ', help='baz help')
parser_b.add_argument('--fff', choices='XYZ', help='b fff help')

c = parser.parse_args()
```
