### PR TITLE
number of clean up and housekeeping tasks

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -22,8 +22,16 @@ from configman.converters import (
     regex_converter,
     timedelta_converter
 )
+
 from configman.environment import environment
-from configman.command_line import command_line
+# this next line brings in command_line and, if argparse is available,
+# a definition of the configman version of ArgumentParser.  Why is it done
+# with "import *" ? Because we don't know what symbols to import, the decision
+# about what is symbols exist within the module.  To make the import specific
+# here, it would be necessary to reproduce the same logic that is already
+# in the commandline module.
+from configman.commandline import *
+
 
 
 #------------------------------------------------------------------------------

--- a/configman/commandline.py
+++ b/configman/commandline.py
@@ -5,5 +5,6 @@
 # this will be expanded in the future when additional command line libraries
 # are supported
 
+# at which point we want to make argparse the default, we will eliminate
+# this line
 import getopt as command_line
-

--- a/configman/converters.py
+++ b/configman/converters.py
@@ -412,8 +412,8 @@ py_obj_to_str = arbitrary_object_to_string  # for backwards compatibility
 
 
 #------------------------------------------------------------------------------
-def list_to_str(a_list):
-    return ', '.join(to_str(x) for x in a_list)
+def list_to_str(a_list, delimiter=', '):
+    return delimiter.join(to_str(x) for x in a_list)
 
 #------------------------------------------------------------------------------
 known_mapping_type_to_str = dict(

--- a/configman/def_sources/__init__.py
+++ b/configman/def_sources/__init__.py
@@ -14,10 +14,8 @@ from configman.def_sources import for_json
 definition_dispatch = {
   collections.Mapping: for_mappings.setup_definitions,
   type(for_modules): for_modules.setup_definitions,
-  #list: for_list.setup_definitions,
   str: for_json.setup_definitions,
   unicode: for_json.setup_definitions,
-  #type: for_class.setup_definitions,
 }
 
 

--- a/configman/option.py
+++ b/configman/option.py
@@ -35,6 +35,7 @@ class Option(object):
         reference_value_from=None,
         secret=False,
         has_changed=False,
+        foreign_data=None,
     ):
         self.name = name
         self.short_form = short_form
@@ -63,6 +64,7 @@ class Option(object):
         self.reference_value_from = reference_value_from
         self.secret = secret
         self.has_changed = has_changed
+        self.foreign_data = foreign_data
 
     #--------------------------------------------------------------------------
     def __str__(self):
@@ -97,7 +99,9 @@ class Option(object):
         if self.default is None:
             return '<Option: %r>' % self.name
         else:
-            return '<Option: %r, default=%r>' % (self.name, self.default)
+            return '<Option: %r, default=%r, value=%r, is_argument=%r>' % (
+                self.name, self.default, self.value, self.is_argument
+            )
 
     #--------------------------------------------------------------------------
     def _deduce_converter(self, default):
@@ -191,6 +195,7 @@ class Option(object):
             reference_value_from=self.reference_value_from,
             secret=self.secret,
             has_changed=self.has_changed,
+            foreign_data=self.foreign_data,
         )
         return o
 

--- a/configman/tests/test_config_files.py
+++ b/configman/tests/test_config_files.py
@@ -14,7 +14,7 @@ from configman.namespace import Namespace
 from configman.config_manager import ConfigurationManager
 from configman.config_file_future_proxy import ConfigFileFutureProxy
 
-from configman.command_line import command_line
+from configman import command_line
 
 
 #--------------------------------------------------------------------------

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -14,6 +14,7 @@ import getopt
 import mock
 
 import configman.config_manager as config_manager
+from configman.commandline import command_line
 from configman.option import Option
 from configman.dotdict import (
     DotDict,
@@ -21,6 +22,7 @@ from configman.dotdict import (
     create_key_translating_dot_dict,
 )
 from configman import Namespace, RequiredConfig
+from configman.config_file_future_proxy import ConfigFileFutureProxy
 from configman.converters import class_converter
 from configman.datetime_util import datetime_from_ISO_string
 from configman.config_exceptions import NotAnOptionError
@@ -770,14 +772,13 @@ c.string =   from ini
             [n],
             use_admin_controls=True,
             use_auto_help=False,
-            argv_source=[],
+            argv_source=['some_app'],
         )
         s = StringIO()
         c.output_summary(output_stream=s)
         r = s.getvalue()
-        self.assertTrue('OPTIONS:\n' in r)
+        self.assertTrue('[OPTIONS]... ' in r)
         self.assertTrue('application' in r)  # yeah, we want to see option
-        self.assertFalse('[ application' in r)  # but don't want it optional
 
     #--------------------------------------------------------------------------
     def test_output_summary_with_argument_2(self):
@@ -2104,7 +2105,8 @@ c.string =   from ini
 
         cm = config_manager.ConfigurationManager(
             (n,),
-            argv_source=[]
+            values_source_list=[ConfigFileFutureProxy, getopt],
+            argv_source=[],
         )
         opts = cm.get_option_names()
         for an_opt in opts:

--- a/configman/tests/test_val_for_modules.py
+++ b/configman/tests/test_val_for_modules.py
@@ -20,6 +20,7 @@ from configman import (
 from configman.option import Option
 from configman.config_exceptions import CannotConvertError, NotAnOptionError
 from configman.value_sources.for_modules import ValueSource
+from configman.converters import class_converter
 
 
 #==============================================================================
@@ -47,6 +48,20 @@ class Beta(RequiredConfig):
         self.config = config
         self.b = config.b
 
+#==============================================================================
+class Delta(RequiredConfig):
+    required_config = Namespace()
+    required_config.add_option(
+        'messy',
+        doc='messy',
+        default=-99
+    )
+    required_config.add_option(
+        'dd',
+        doc='dd',
+        default=Beta,
+        from_string_converter=class_converter
+    )
 
 #==========================================================================
 class TestCase(unittest.TestCase):

--- a/configman/value_sources/for_getopt.py
+++ b/configman/value_sources/for_getopt.py
@@ -241,3 +241,13 @@ class ValueSource(object):
                 # this option definition does have the concept of being
                 # an argument - likely an aggregation
                 pass
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _setup_auto_help(the_config_manager):
+        help_option = option.Option(
+            name='help',
+            doc='print this',
+            default=False
+        )
+        the_config_manager.definition_source_list.append({'help': help_option})

--- a/demo/advanced_demo1.py
+++ b/demo/advanced_demo1.py
@@ -41,7 +41,6 @@ def define_config():
       name='host',
       default='localhost',
       doc='the hostname of the database',
-      short_form='h'
     )
     definition.add_option(
       name='dbname',


### PR DESCRIPTION
this represents a number of tasks that clean up of various issues. 

1) prepare to support multiple command_line value sources.  That means rework where we decide to do help
2) add the ability to use a "$" suffix on an option to signal that the option is not to be written out to a configuration file.  This will enable the future argparse support to have multiple arguments with the same name.
3) move fetching value sources out the inner most loop in the overlay/expand loops.  That is much more efficient.
4) several formatting cleanups
