### PR TITLE
print doc in env output - fixes #151

### DIFF
--- a/configman/tests/test_val_for_mapping.py
+++ b/configman/tests/test_val_for_mapping.py
@@ -128,17 +128,56 @@ class TestCase(unittest.TestCase):
         cm.write_conf(for_mapping, opener=stringIO_context_wrapper(out))
         received = out.getvalue()
         out.close()
-        expected = """aaa='2011-05-04T15:10:00'
+        expected = """
+# the a (default: '2011-05-04T15:10:00')
+aaa='2011-05-04T15:10:00'
 
+# your uncle (default: 98)
 c__dwight='98'
+# husband from Flintstones (default: 'stupid')
 c__fred='stupid'
+# wife from Flintstones (default: 'waspish')
 c__wilma='waspish'
 
+# my uncle (default: 97)
 c__e__dwight='97'
 
+# female neighbor from I Love Lucy (default: 'silly')
 d__ethel='silly'
+# male neighbor from I Love Lucy (default: 'crabby')
 d__fred='crabby'
 
+# the password (default: 'secret')
 x__password='secret'
-x__size='100'"""
+# how big in tons (default: 100)
+x__size='100'
+        """.strip()
+        self.assertEqual(received.strip(), expected)
+
+    #--------------------------------------------------------------------------
+    def test_for_mapping_long_doc_in_write_conf(self):
+        n = self._some_namespaces()
+        n = Namespace(doc='top')
+        n.add_option(
+            'aaa',
+            'Default Value Goes In Here',
+            'This time the documentation string is really long. So long '
+            'that we have to write it on multiple lines.',
+        )
+        cm = ConfigurationManager(
+            n,
+            values_source_list=[],
+        )
+        out = StringIO()
+        cm.write_conf(for_mapping, opener=stringIO_context_wrapper(out))
+        received = out.getvalue()
+        out.close()
+        lines = received.splitlines()
+        for line in received.splitlines():
+            self.assertTrue(len(line) < 80, line)
+        expected = """
+# This time the documentation string is really long. So long that we have to
+# write it on multiple lines. (default: 'Default Value Goes In Here')
+aaa='Default Value Goes In Here'
+        """.strip()
         self.assertEqual(received.strip(), expected)

--- a/configman/value_sources/for_mapping.py
+++ b/configman/value_sources/for_mapping.py
@@ -72,6 +72,20 @@ class ValueSource(object):
             for key, value in source_dict.items()
             if isinstance(value, namespace.Namespace)
         ]
+
+        def split_long_line(line, prefix='\n', max_length=80):
+            parts = line.split()
+            lines = []
+            one = []
+            for part in parts:
+                if len(' '.join(one + [part])) > max_length - len(prefix):
+                    lines.append(one)
+                    one = []
+                one.append(part)
+            lines.append(one)
+            lines.insert(0, '')
+            return prefix.join([' '.join(x) for x in lines])
+
         for an_option in options:
             if namespace_name:
                 option_name = "%s.%s" % (namespace_name, an_option.name)
@@ -80,6 +94,13 @@ class ValueSource(object):
             option_value = str(an_option)
             if isinstance(option_value, unicode):
                 option_value = option_value.encode('utf8')
+
+            comment_line = '%s (default: %r)' % (
+                an_option.doc or '',
+                an_option.default
+            )
+            comment_lines = split_long_line(comment_line, '\n# ').lstrip()
+            print >>output_stream, comment_lines
 
             option_format = '%s=%r'
             print >>output_stream, option_format % (


### PR DESCRIPTION
@twobraids r? (cc @rhelmer )

[Before](https://github.com/mozilla/configman/blob/19c49861118b852cc86a28647ae3aca896a6c77a/configman/tests/test_val_for_mapping.py#L131-L143) 
[After](https://github.com/mozilla/configman/blob/73a527e4b8f0e9d2f60d1ee0d42cdc1a76b2ec21/configman/tests/test_val_for_mapping.py#L132-L153)

Note how there's a single `\n` between options but a double `\n\n` between namespaces so to say. 