### PR TITLE
sorted the ignored_symbols_list

### DIFF
--- a/configman/value_sources/for_modules.py
+++ b/configman/value_sources/for_modules.py
@@ -447,7 +447,7 @@ class ValueSource(object):
                 "# suppress the mismatch warning since these symbols are\n" \
                 "# values for options, not option names themselves."
             print >>output_stream, "ignore_symbol_list = ["
-            for a_symbol in symbols_to_ignore:
+            for a_symbol in sorted(symbols_to_ignore):
                 print >>output_stream, '    "%s",' % a_symbol
             print >>output_stream, ']\n'
 


### PR DESCRIPTION
it is unwise to depend on default sort orders of lists in tests.  This PR breaks a dependency on a sort order that causes trouble on some platforms.
