### PR TITLE
Add support for argparse as either a definition or overlay value source

### DIFF
--- a/configman/__init__.py
+++ b/configman/__init__.py
@@ -26,7 +26,7 @@ from configman.converters import (
 from configman.environment import environment
 # this next line brings in command_line and, if argparse is available,
 # a definition of the configman version of ArgumentParser.  Why is it done
-# with "import *" ? Because we don't know what symbols to import, the decision
+# with "import *" ? Because I don't know what symbols to import, the decision
 # about what is symbols exist within the module.  To make the import specific
 # here, it would be necessary to reproduce the same logic that is already
 # in the commandline module.
@@ -45,4 +45,3 @@ def configuration(*args, **kwargs):
         config_kwargs = {}
     cm = ConfigurationManager(*args, **kwargs)
     return cm.get_config(**config_kwargs)
-

--- a/configman/commandline.py
+++ b/configman/commandline.py
@@ -8,3 +8,11 @@
 # at which point we want to make argparse the default, we will eliminate
 # this line
 import getopt as command_line
+
+try:
+    # keep this commented out until we want argparse as the default
+    # import argparse as command_line
+    from configman.def_sources.for_argparse import ArgumentParser
+except ImportError:
+    # argparse is not available, we can silently ignore this problem
+    pass

--- a/configman/def_sources/__init__.py
+++ b/configman/def_sources/__init__.py
@@ -19,6 +19,16 @@ definition_dispatch = {
 }
 
 
+try:
+    from configman.def_sources import for_argparse
+    import argparse
+    definition_dispatch[argparse.ArgumentParser] = \
+        for_argparse.setup_definitions
+except ImportError:
+    # silently ignore that argparse doesn't exist
+    pass
+
+
 class UnknownDefinitionTypeException(Exception):
     pass
 

--- a/configman/def_sources/for_argparse.py
+++ b/configman/def_sources/for_argparse.py
@@ -2,13 +2,672 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# this is a stub for future implementation
+"""this module introduces support for argparse as a data definition source
+for configman.  Rather than write using configman's data definition language,
+programsd can instead use the familiar argparse method."""
 
-try:
-    import argparse
+import argparse
+import inspect
+from os import environ
+from functools import partial
 
-    def setup_definitions(source, destination):
-        pass
+from configman.namespace import Namespace
+from configman.config_file_future_proxy import ConfigFileFutureProxy
+from configman.dotdict import (
+    DotDict,
+    iteritems_breadth_first,
+    create_key_translating_dot_dict
+)
+from configman.converters import (
+    str_to_instance_of_type_converters,
+    str_to_list,
+    boolean_converter,
+    to_str,
+    CannotConvertError
+)
 
-except ImportError:
-    pass
+
+#-----------------------------------------------------------------------------
+# horrors
+# argparse is not very friendly toward extension in this manner.  In order to
+# fully exploit argparse, it is necessary to reach inside it to examine some
+# of its internal structures that are not intended for external use.  These
+# invasive methods are restricted to read-only.
+#------------------------------------------------------------------------------
+def find_action_name_by_value(registry, target_action_instance):
+    """the association of a name of an action class with a human readable
+    string is exposed externally only at the time of argument definitions.
+    This routine, when given a reference to argparse's internal action
+    registry and an action, will find that action and return the name under
+    which it was registered.
+    """
+    target_type = type(target_action_instance)
+    for key, value in registry['action'].iteritems():
+        if value is target_type:
+            if key is None:
+                return 'store'
+            return key
+    return None
+
+
+#------------------------------------------------------------------------------
+def get_args_and_values(parser, an_action):
+    """this rountine attempts to reconstruct the kwargs that were used in the
+    creation of an action object"""
+    args = inspect.getargspec(an_action.__class__.__init__).args
+    kwargs = dict(
+        (an_attr, getattr(an_action, an_attr))
+        for an_attr in args
+        if (
+            an_attr not in ('self', 'required')
+            and getattr(an_action, an_attr) is not None
+        )
+    )
+    action_name = find_action_name_by_value(
+        parser._optionals._registries,
+        an_action
+    )
+    if 'required' in kwargs:
+        del kwargs['required']
+    kwargs['action'] = action_name
+    if 'option_strings' in kwargs:
+        args = tuple(kwargs['option_strings'])
+        del kwargs['option_strings']
+    else:
+        args = ()
+    return args, kwargs
+
+
+#==============================================================================
+class SubparserFromStringConverter(object):
+    """this class serves as both a repository of namespace sets corresponding
+    with subparsers, and a from string converer. It is used in configman as the
+    from_string_converter for the Option that corresponds with the subparser
+    argparse action.  Once configman as assigned the final value to the
+    subparser, it leaves an instance of the SebparserValue class as the default
+    for the subparser configman option.  A deriviative of a string, this class
+    also contains the configman required config corresponding to the actions
+    of the subparsers."""
+    #--------------------------------------------------------------------------
+    def __init__(self):
+        self.namespaces = {}
+
+    #--------------------------------------------------------------------------
+    def add_namespace(self, name, a_namespace):
+        """as we build up argparse, the actions that define a subparser are
+        translated into configman options.  Each of those options must be
+        tagged with the value of the subparse to which they correspond."""
+        # save a local copy of the namespace
+        self.namespaces[name] = a_namespace
+        # iterate through the namespace branding each of the options with the
+        # name of the subparser to which they belong
+        for k in a_namespace.keys_breadth_first():
+            an_option = a_namespace[k]
+            if not an_option.foreign_data:
+                an_option.foreign_data = DotDict()
+            an_option.foreign_data['argparse.owning_subparser_name'] = name
+
+    #--------------------------------------------------------------------------
+    def __call__(self, subparser_name):
+        """As an instance of this class must serve as a from_string_converter,
+        it must behave like a function.  This method gives an instance of this
+        class function semantics"""
+        #======================================================================
+        class SubparserValue(str):
+            """Instances of this class/closure serve as the value given out as
+            the final value of the subparser configman option.  It is a string,
+            that also has a 'get_required_config' method that can bring in the
+            the arguments defined in the subparser in the local namespace.
+            The mechanism works in the same manner that configman normally does
+            expansion of dynamically loaded classes."""
+            required_config = Namespace()
+            try:
+                # define the class dynamically, giving it the required_config
+                # that corresponds with the confiman options defined for the
+                # subparser of the same name.
+                required_config = self.namespaces[subparser_name]
+            except KeyError:
+                raise CannotConvertError(
+                    '%s is not a known sub-command' % subparser_name
+                )
+
+            #------------------------------------------------------------------
+            def __new__(cls):
+                """deriving from string is tricky business.  You cannot set the
+                value in an __init__ method because strings are immutable and
+                __init__ time is too late.  The 'new' method is the only chance
+                to properly set the value."""
+                obj = str.__new__(cls, subparser_name)
+                return obj
+
+            #------------------------------------------------------------------
+            def get_required_config(self):
+                return self.required_config
+
+            #------------------------------------------------------------------
+            def to_str(self):
+                return subparser_name
+        # instantiate the class and return it.  It will be assigned as the
+        # value for the configman option corresponding with the subparser
+        return SubparserValue()
+
+
+#==============================================================================
+class ConfigmanSubParsersAction(argparse._SubParsersAction):
+    """this is a derivation of the argpares _SubParsersAction action.  We
+    require its use over the default _SubParsersAction because we need to
+    preserve the original args & kwargs that created it.  They will be used
+    in a later phase of configman to perfectly reproduce the object without
+    having to resort to a copy."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.original_args = args
+        self.original_kwargs = kwargs
+        super(ConfigmanSubParsersAction, self).__init__(*args, **kwargs)
+
+    #--------------------------------------------------------------------------
+    def add_parser(self, *args, **kwargs):
+        """each time a subparser action is used to create a new parser object
+        we must save the original args & kwargs.  In a later phase of
+        configman, we'll need to reproduce the subparsers exactly without
+        resorting to copying.  We save the args & kwargs in the 'foreign_data'
+        section of the configman option that corresponds with the subparser
+        action."""
+        command_name = args[0]
+        new_kwargs = kwargs.copy()
+        new_kwargs['configman_subparsers_option'] = self._configman_option
+        new_kwargs['subparser_name'] = command_name
+        subparsers = self._configman_option.foreign_data.argparse.subparsers
+        a_subparser = super(ConfigmanSubParsersAction, self).add_parser(
+            *args,
+            **new_kwargs
+        )
+        subparsers[command_name] = DotDict({
+            "args": args,
+            "kwargs": new_kwargs,
+            "subparser": a_subparser
+        })
+        return a_subparser
+
+    #--------------------------------------------------------------------------
+    def add_configman_option(self, an_option):
+        self._configman_option = an_option
+
+
+#==============================================================================
+class ArgumentParser(argparse.ArgumentParser):
+    """this subclass of the standard argparse parser to be used as a drop in
+    replacement for argparse.ArgumentParser.  It hijacks the standard
+    parsing methods and hands off to configman.  Configman then calls back
+    to the standard argparse base class to actually do the work, intercepting
+    the final output do its overlay magic. The final result is not an
+    argparse Namespace object, but a configman DotDict.  This means that it
+    is functionlly equivalent to the argparse Namespace with the additional
+    benefit of being compliant with the collections.Mapping abstract base
+    class."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.original_args = args
+        self.original_kwargs = kwargs.copy()
+        kwargs['add_help'] = False  # stop help, reintroduce it later
+        self.subparser_name = kwargs.pop('subparser_name', None)
+        self.configman_subparsers_option = kwargs.pop(
+            'configman_subparsers_option',
+            None
+        )
+        super(ArgumentParser, self).__init__(*args, **kwargs)
+        self.value_source_list = [environ, ConfigFileFutureProxy, argparse]
+        self.required_config = Namespace()
+
+    #--------------------------------------------------------------------------
+    def get_required_config(self):
+        """because of the exsistance of subparsers, the configman options
+        that correspond with argparse arguments are not a constant.  We need
+        to produce a copy of the namespace rather than the actual embedded
+        namespace."""
+        required_config = Namespace()
+        # add current options to a copy of required config
+        for k, v in iteritems_breadth_first(self.required_config):
+            required_config[k] = v
+        # get any option found in any subparsers
+        try:
+            subparser_namespaces = (
+                self.configman_subparsers_option.foreign_data
+                .argparse.subprocessor_from_string_converter
+            )
+            subparsers = (
+                self._argparse_subparsers._configman_option.foreign_data
+                .argparse.subparsers
+            )
+            # each subparser needs to have its configman options set up
+            # in the subparser's configman option.  This routine copies
+            # the required_config of each subparser into the
+            # SubparserFromStringConverter defined above.
+            for subparser_name, subparser_data in subparsers.iteritems():
+                subparser_namespaces.add_namespace(
+                    subparser_name,
+                    subparser_data.subparser.get_required_config()
+                )
+        except AttributeError:
+            # there is no subparser
+            pass
+        return required_config
+
+    #--------------------------------------------------------------------------
+    def add_argument(self, *args, **kwargs):
+        """this method overrides the standard in order to create a parallel
+        argument system in both the argparse and configman worlds.  Each call
+        to this method returns a standard argparse Action object as well as
+        adding an equivalent configman Option object to the required_config
+        for this object.  The original args & kwargs that defined an argparse
+        argument are preserved in the 'foreign_data' section of the
+        corresponding configman Option."""
+        # pull out each of the argument definition components from the args
+        # so that we can deal with them one at a time in a well labeled manner
+        # In this section, variables beginning with the prefix "argparse" are
+        # values that define Action object.  Variables that begin with
+        # "configman" are the arguments to create configman Options.
+        argparse_action_name = kwargs.get('action', None)
+        argparse_dest = kwargs.get('dest', None)
+        argparse_const = kwargs.get('const', None)
+        argparse_default = kwargs.get('default', None)
+        if argparse_default is argparse.SUPPRESS:
+            # we'll be forcing all options to have the attribute of
+            # argparse.SUPPRESS later.  It's our way of making sure that
+            # argparse returns only values that the user explicitly added to
+            # the command line.
+            argparse_default = None
+        argparse_nargs = kwargs.get('nargs', None)
+        argparse_type = kwargs.get('type', None)
+        argparse_suppress_help = kwargs.pop('suppress_help', False)
+        if argparse_suppress_help:
+            configman_doc = kwargs.get('help', '')
+            kwargs['help'] = argparse.SUPPRESS
+        else:
+            argparse_help = kwargs.get('help', '')
+            if argparse_help == argparse.SUPPRESS:
+                configman_doc = ''
+            else:
+                configman_doc = argparse_help
+
+        # we need to make sure that all arguments that the user has not
+        # explicily set on the command line have this attribute.  This means
+        # that when the argparse parser returns the command line values, it
+        # will not return values that the user did not mention on the command
+        # line.  The defaults that otherwise would have been returned will be
+        # handled by configman.
+        kwargs['default'] = argparse.SUPPRESS
+        # forward all parameters to the underlying base class to create a
+        # normal argparse action object.
+        an_action = super(ArgumentParser, self).add_argument(
+            *args,
+            **kwargs
+        )
+        argparse_option_strings = an_action.option_strings
+
+        # get a human readable string that identifies the type of the argparse
+        # action class that was created
+        if argparse_action_name is None:
+            argparse_action_name = find_action_name_by_value(
+                self._optionals._registries,
+                an_action
+            )
+
+        configman_is_argument = False
+
+        # each of argparse's Action types must be handled separately.
+        #--------------------------------------------------------------------
+        # STORE
+        if argparse_action_name == 'store':
+            if argparse_dest is None:
+                configman_name, configman_is_argument = self._get_option_name(
+                    args
+                )
+                if not configman_name:
+                    configman_name = args[0]
+            else:
+                configman_name = argparse_dest
+                configman_is_argument = not argparse_option_strings
+            configman_default = argparse_default
+            if argparse_nargs and argparse_nargs in "1?":
+                if argparse_type:
+                    configman_from_string = argparse_type
+                elif argparse_default:
+                    configman_from_string = (
+                        str_to_instance_of_type_converters.get(
+                            type(argparse_default),
+                            str
+                        )
+                    )
+                else:
+                    configman_from_string = str
+            elif argparse_nargs and argparse_type:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=argparse_type,
+                    item_separator=' ',
+                )
+            elif argparse_nargs and argparse_default:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=str_to_instance_of_type_converters.get(
+                        type(argparse_default),
+                        str
+                    ),
+                    item_separator=' ',
+                )
+            elif argparse_nargs:
+                configman_from_string = partial(
+                    str_to_list,
+                    item_converter=str,
+                    item_separator=' ',
+                )
+            elif argparse_type:
+                configman_from_string = argparse_type
+            elif argparse_default:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_default),
+                    str
+                )
+            else:
+                configman_from_string = str
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # STORE_CONST
+        elif argparse_action_name == 'store_const':
+            if argparse_dest is None:
+                configman_name, configman_is_argument = self._get_option_name(
+                    args
+                )
+                if not configman_name:
+                    configman_name = args[0]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_const),
+                    str
+                )
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # STORE_TRUE /  STORE_FALSE
+        elif (
+            argparse_action_name == 'store_true'
+            or argparse_action_name == 'store_false'
+        ):
+            if argparse_dest is None:
+                configman_name, configman_is_argument = self._get_option_name(
+                    args
+                )
+                if not configman_name:
+                    configman_name = args[0]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            configman_from_string = boolean_converter
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # APPEND
+        elif argparse_action_name == 'append':
+            if argparse_dest is None:
+                configman_name, configman_is_argument = self._get_option_name(
+                    args
+                )
+                if not configman_name:
+                    configman_name = args[0]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # APPEND_CONST
+        elif argparse_action_name == 'append_const':
+            if argparse_dest is None:
+                configman_name, configman_is_argument = self._get_option_name(
+                    args
+                )
+                if not configman_name:
+                    configman_name = args[0]
+            else:
+                configman_name = argparse_dest
+            configman_default = argparse_default
+            if argparse_type:
+                configman_from_string = argparse_type
+            else:
+                configman_from_string = str_to_instance_of_type_converters.get(
+                    type(argparse_const),
+                    str
+                )
+            configman_to_string = to_str
+
+        #--------------------------------------------------------------------
+        # VERSION
+        elif argparse_action_name == 'version':
+            return an_action
+
+        #--------------------------------------------------------------------
+        # OTHER
+        else:
+            configman_name = argparse_dest
+
+        # configman uses the switch name as the name of the key inwhich to
+        # store values.  argparse is able to use different names for each.
+        # this means that configman may encounter repeated targets.  Rather
+        # than overwriting Options with new ones with the same name, configman
+        # renames them by appending the '$' character.
+        while configman_name in self.required_config:
+            configman_name = "%s$" % configman_name
+        configman_not_for_definition = configman_name.endswith('$')
+
+        # it's finally time to create the configman Option object and add it
+        # to the required_config.
+        self.required_config.add_option(
+            name=configman_name,
+            default=configman_default,
+            doc=configman_doc,
+            from_string_converter=configman_from_string,
+            to_string_converter=configman_to_string,
+            #short_form=configman_short_form,
+            is_argument=configman_is_argument,
+            not_for_definition=configman_not_for_definition,
+            # we're going to save the args & kwargs that created the
+            # argparse Action.  This enables us to perfectly reproduce the
+            # the original Action object later during the configman overlay
+            # process.
+            foreign_data=DotDict({
+                'argparse.flags.subcommand': False,
+                'argparse.args': args,
+                'argparse.kwargs': kwargs,
+                'argparse.owning_subparser_name': self.subparser_name,
+            })
+        )
+        return an_action
+
+    #--------------------------------------------------------------------------
+    def add_subparsers(self, *args, **kwargs):
+        """When adding a subparser, we need to ensure that our version of the
+        SubparserAction object is returned.  We also need to create the
+        corresponding configman Option object for the subparser and pack it's
+        foreign data section with the original args & kwargs."""
+
+        kwargs['parser_class'] = self.__class__
+        kwargs['action'] = ConfigmanSubParsersAction
+
+        subparser_action = super(ArgumentParser, self).add_subparsers(
+            *args,
+            **kwargs
+        )
+        self._argparse_subparsers = subparser_action
+
+        if "dest" not in kwargs or kwargs['dest'] is None:
+            kwargs['dest'] = 'subcommand'
+        configman_name = kwargs['dest']
+        configman_default = None
+        configman_doc = kwargs.get('help', '')
+        subprocessor_from_string_converter = SubparserFromStringConverter()
+        configman_to_string = str
+        configman_is_argument = True
+        configman_not_for_definition = True
+
+        # it's finally time to create the configman Option object and add it
+        # to the required_config.
+        self.required_config.add_option(
+            name=configman_name,
+            default=configman_default,
+            doc=configman_doc,
+            from_string_converter=subprocessor_from_string_converter,
+            to_string_converter=configman_to_string,
+            is_argument=configman_is_argument,
+            not_for_definition=configman_not_for_definition,
+            # we're going to save the input parameters that created the
+            # argparse Action.  This enables us to perfectly reproduce the
+            # the original Action object later during the configman overlay
+            # process.
+            foreign_data=DotDict({
+                'argparse.flags.subcommand': subparser_action,
+                'argparse.args': args,
+                'argparse.kwargs': kwargs,
+                'argparse.subparsers': DotDict(),
+                'argparse.subprocessor_from_string_converter':
+                subprocessor_from_string_converter
+            })
+        )
+
+        self.configman_subparsers_option = self.required_config[configman_name]
+        subparser_action.add_configman_option(self.configman_subparsers_option)
+
+        return subparser_action
+
+    #--------------------------------------------------------------------------
+    def set_defaults(self, **kwargs):
+        """completely take over the 'set_defaults' system of argparse, because
+        configman has no equivalent.  These will be added back to the configman
+        result at the very end."""
+        self.extra_defaults = kwargs
+
+    #--------------------------------------------------------------------------
+    def parse_args(self, args=None, namespace=None):
+        """this method hijacks the normal argparse Namespace generation,
+        shimming configman into the process. The return value will be a
+        configman DotDict rather than an argparse Namespace."""
+        # load the config_manager within the scope of the method that uses it
+        # so that we avoid circular references in the outer scope
+        from configman.config_manager import ConfigurationManager
+
+        configuration_manager = ConfigurationManager(
+            definition_source=[self.get_required_config()],
+            values_source_list=self.value_source_list,
+            argv_source=args,
+            app_name=self.prog,
+            app_version=self.version,
+            app_description=self.description,
+            use_auto_help=False,
+        )
+
+        # it is apparent a common idiom that commandline options may have
+        # embedded '-' characters in them.  Configman requires that option
+        # follow the Python Identifier rules.  Fortunately, Configman has a
+        # class that will perform dynamic translation of keys.  In this
+        # code fragment, we fetch the final configuration from configman
+        # using a Mapping that will translate keys with '-' into keys with
+        # '_' instead.
+        conf = configuration_manager.get_config(
+            mapping_class=create_key_translating_dot_dict(
+                "HyphenUnderscoreDict",
+                (('-', '_'),)
+            )
+        )
+
+        # here is where we add the values given to "set_defaults" method
+        # of argparse.
+        if self.configman_subparsers_option:
+            subparser_name = conf[self.configman_subparsers_option.name]
+            try:
+                conf.update(
+                    self.configman_subparsers_option.foreign_data.argparse
+                    .subparsers[subparser_name].subparser
+                    .extra_defaults
+                )
+            except (AttributeError, KeyError):
+                # no extra_defaults skip on
+                pass
+
+        if hasattr(self, 'extra_defaults'):
+            conf.update(self.extra_defaults)
+
+        return conf
+
+    #--------------------------------------------------------------------------
+    def parse_known_args(self, args=None, namespace=None):
+        """this method hijacks the normal argparse Namespace generation,
+        shimming configman into the process. The return value will be a
+        configman DotDict rather than an argparse Namespace."""
+        # load the config_manager within the scope of the method that uses it
+        # so that we avoid circular references in the outer scope
+        from configman.config_manager import ConfigurationManager
+        configuration_manager = ConfigurationManager(
+            definition_source=[self.get_required_config()],
+            values_source_list=self.value_source_list,
+            argv_source=args,
+            app_name=self.prog,
+            app_version=self.version,
+            app_description=self.description,
+            use_auto_help=False,
+        )
+        conf = configuration_manager.get_config(
+            mapping_class=create_key_translating_dot_dict(
+                "HyphenUnderscoreDict",
+                (('-', '_'),)
+            )
+        )
+        return conf
+
+    #--------------------------------------------------------------------------
+    def _get_option_name(self, args):
+        # argparse is loose in the manner that it names arguments.  Sometimes
+        # it comes in as the 'dest' kwarg, othertimes it is deduced from args
+        # as the first "long" style argument in the args.  This method
+        long_name = []
+        short_name = None
+        for an_option in args:
+            if an_option[0] in self.prefix_chars:
+                if an_option[1] in self.prefix_chars:
+                    return an_option[2:], False
+                if not short_name:
+                    short_name = an_option[1:]
+            else:
+                return an_option, True
+        if short_name:
+            return short_name, False
+        return None
+
+#------------------------------------------------------------------------------
+def setup_definitions(source, destination):
+    """this method stars the process of configman reading and using an argparse
+    instance as a source of configuration definitions."""
+    #"""assume that source is of type argparse
+    try:
+        destination.update(source.get_required_config())
+    except AttributeError:
+        # looks like the user passed in a real arpgapse parser rather than our
+        # bastardized version of one.  No problem, we can work with it,
+        # though the translation won't be as perfect.
+        our_parser = ArgumentParser()
+        for i, an_action in enumerate(source._actions):
+            args, kwargs = get_args_and_values(source, an_action)
+            dest = kwargs.get('dest', '')
+            if dest in ('help', 'version'):
+                continue
+            our_parser.add_argument(*args, **kwargs)
+        destination.update(our_parser.get_required_config())

--- a/configman/def_sources/for_argparse.py
+++ b/configman/def_sources/for_argparse.py
@@ -375,7 +375,10 @@ class ArgumentParser(argparse.ArgumentParser):
 
         #--------------------------------------------------------------------
         # STORE_CONST
-        elif argparse_action_name == 'store_const':
+        elif (
+            argparse_action_name == 'store_const'
+            or argparse_action_name == 'count'
+        ):
             if argparse_dest is None:
                 configman_name, configman_is_argument = self._get_option_name(
                     args

--- a/configman/tests/test_config_manager.py
+++ b/configman/tests/test_config_manager.py
@@ -13,6 +13,9 @@ import getopt
 
 import mock
 
+import argparse
+import getopt
+
 import configman.config_manager as config_manager
 from configman.commandline import command_line
 from configman.option import Option

--- a/configman/tests/test_def_for_argparse.py
+++ b/configman/tests/test_def_for_argparse.py
@@ -1,0 +1,482 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittest import TestCase
+from mock import patch
+
+
+from StringIO import StringIO
+
+try:
+    import argparse
+except ImportError:
+    try:
+        from unittest import SkipTest
+    except ImportError:
+        from nose.plugins.skip import SkipTest
+    raise SkipTest
+
+from configman import ArgumentParser
+from configman.dotdict import DotDict
+
+expected_value = {
+    "test_expansion_subparsers_1":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+
+positional arguments:
+  {a,b}                 sub-command help
+    a                   a help
+    b                   b help
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --foo                 foo help
+  --egg EGG             eggs
+""",
+
+    "test_expansion_subparsers_2":
+"""usage: highwater a [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--fff FFF]
+                   bar
+
+positional arguments:
+  bar                   bar help
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --fff FFF             a fff help
+""",
+    "test_expansion_subparsers_3":
+"""usage: highwater b [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--baz {X,Y,Z}] [--fff {X,Y,Z}]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --admin.print_conf ADMIN.PRINT_CONF
+                        write current config to stdout (json, py, conf, env,
+                        ini)
+  --admin.dump_conf ADMIN.DUMP_CONF
+                        a pathname to which to write the current config
+  --admin.strict        mismatched options generate exceptions rather than
+                        just warnings
+  --admin.expose_secrets
+                        should options marked secret get written out or
+                        hidden?
+  --admin.conf ADMIN.CONF
+                        the pathname of the config file (path/filename)
+  --baz {X,Y,Z}         baz help
+  --fff {X,Y,Z}         b fff help
+""",
+    "test_expansion_subparsers_4":
+"""usage: highwater [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: argument sub_command: invalid choice: 'c' (choose from 'a', 'b')
+""",
+    "test_expansion_subparsers_5":
+"""usage: highwater a [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                   [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                   [--admin.expose_secrets] [--admin.conf ADMIN.CONF]
+                   [--fff FFF]
+                   bar
+highwater a: error: too few arguments
+""",
+    "test_expansion_subparsers_6":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: unrecognized arguments: --baz Y
+""",
+    "test_expansion_subparsers_7":
+"""usage: highwater [-h] [--admin.print_conf ADMIN.PRINT_CONF]
+                 [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
+                 [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
+                 [--egg EGG]
+                 {a,b} ...
+highwater: error: unrecognized arguments: 16
+""",
+    "test_expansion_subparsers_defaults_values_1":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'a',
+        'bar': 16,
+        'fff': None,
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+    "test_expansion_subparsers_defaults_values_2":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'a',
+        'bar': 16,
+        'fff': 9,
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+    "test_expansion_subparsers_defaults_values_3":
+    DotDict({
+        'foo': None,
+        'egg': None,
+        'sub_command': 'b',
+        'baz': None,
+        'fff': 'X',
+        'admin.print_conf': None,
+        'admin.dump_conf': '',
+        'admin.strict': False,
+        'admin.expose_secrets': False,
+        'admin.conf': './highwater.ini',
+    }),
+}
+
+
+#==============================================================================
+class TestCaseForDefSourceArgparse(TestCase):
+
+    #--------------------------------------------------------------------------
+    def setup_argparse(self):
+        parser = ArgumentParser(prog='hell')
+        parser.add_argument(
+            '-s',
+            action='store',
+            dest='simple_value',
+            help='Store a simple value'
+        )
+        parser.add_argument(
+            '--missing_from_help',
+            action='store',
+            dest='missing_from_help',
+            help='should not be seen in help',
+            suppress_help=True,
+        )
+        parser.add_argument(
+            '-c',
+            action='store_const',
+            dest='constant_value',
+            const='value-to-store',
+            help='Store a constant value'
+        )
+        parser.add_argument(
+            '-t',
+            action='store_true',
+            default=False,
+            dest='boolean_switch',
+            help='Set a switch to true'
+        )
+        parser.add_argument(
+            '-f',
+            action='store_false',
+            default=False,
+            dest='boolean_switch',
+            help='Set a switch to false'
+        )
+        parser.add_argument(
+            '-a',
+            action='append',
+            dest='collection',
+            default=[],
+            help='Add repeated values to a list',
+        )
+        parser.add_argument(
+            '-A',
+            action='append_const',
+            dest='const_collection',
+            const='value-1-to-append',
+            default=[],
+            help='Add different values to list'
+        )
+        parser.add_argument(
+            '-B',
+            action='append_const',
+            dest='const_collection',
+            const='value-2-to-append',
+            help='Add different values to list'
+        )
+        parser.add_argument(
+            '--version',
+            action='version',
+            version='%(prog)s 1.0'
+        )
+        return parser
+
+    #--------------------------------------------------------------------------
+    def test_parser_setup(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=[])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_1(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-s', '3', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, '3')
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_2(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-c', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, 'value-to-store')
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_3(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-t', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, True)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_4(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-f', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_5(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-a', '1'])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, ['1'])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_6(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-a', '1', '-a', '2'])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, ['1', '2'])
+        self.assertEqual(config.const_collection, [])
+
+    #--------------------------------------------------------------------------
+    def test_parser_7(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-A', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, ['value-1-to-append'])
+
+    #--------------------------------------------------------------------------
+    def test_parser_8(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-B', ])
+
+        self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(config.const_collection, ['value-2-to-append'])
+
+    #--------------------------------------------------------------------------
+    def test_parser_9(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=['-A', '-B'])
+
+        #self.assertEqual(len(config), 7)
+
+        self.assertEqual(config.simple_value, None)
+        self.assertEqual(config.constant_value, None)
+        self.assertEqual(config.boolean_switch, False)
+        self.assertEqual(config.collection, [])
+        self.assertEqual(
+            config.const_collection,
+            ['value-1-to-append', 'value-2-to-append']
+        )
+
+    #--------------------------------------------------------------------------
+    def test_parser_10(self):
+        parser = self.setup_argparse()
+        config = parser.parse_args(args=[
+            '-A', '-B', '-a', '1', '-s', 'a', '-c', '-t', '-a', '2',
+        ])
+
+        self.assertEqual(config.simple_value, 'a')
+        self.assertEqual(config.constant_value, 'value-to-store')
+        self.assertEqual(config.boolean_switch, True)
+        self.assertEqual(config.collection, ['1', '2'])
+        self.assertEqual(
+            config.const_collection,
+            ['value-1-to-append', 'value-2-to-append']
+        )
+
+    #--------------------------------------------------------------------------
+    def setup_subparser(self):
+        parser = ArgumentParser(prog='highwater')
+        parser.add_argument('--foo', action='store_true', help='foo help', dest='foo')
+        parser.add_argument('--egg', action='store', help='eggs', type=str)
+        subparsers = parser.add_subparsers(help='sub-command help', dest='sub_command')
+        parser_a = subparsers.add_parser('a', help='a help')
+        parser_a.add_argument('bar', type=int, help='bar help')
+        parser_a.add_argument('--fff', type=int, help='a fff help')
+        parser_b = subparsers.add_parser('b', help='b help')
+        parser_b.add_argument('--baz', choices='XYZ', help='baz help')
+        parser_b.add_argument('--fff', choices='XYZ', help='b fff help')
+
+        return parser
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stdout', new_callable=StringIO)
+    def impl_for_subparser_stdout_with_exit(self, args, expected, mock_stdout):
+        parser = self.setup_subparser()
+        self.assertRaises(
+            SystemExit,
+            parser.parse_args,
+            args
+        )
+        x = mock_stdout.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stdout', new_callable=StringIO)
+    def impl_for_subparser_stdout(self, args, expected, mock_stdout):
+        parser = self.setup_subparser()
+        parser.parse_args(args=args)
+        x = mock_stdout.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stderr', new_callable=StringIO)
+    def impl_for_subparser_stderr_with_exit(self, args, expected, mock_stderr):
+        parser = self.setup_subparser()
+        self.assertRaises(
+            SystemExit,
+            parser.parse_args,
+            args
+        )
+        x = mock_stderr.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    @patch('sys.stderr', new_callable=StringIO)
+    def impl_for_subparser_stderr(self, args, expected, mock_stderr):
+        parser = self.setup_subparser()
+        parser.parse_args(args=args)
+        x = mock_stderr.getvalue()
+        self.assertEqual(expected, x, '%s failed' % args)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_stdout_with_exit(self):
+        tests = (
+            (['--help'], expected_value['test_expansion_subparsers_1']),
+            (['a', '--help'], expected_value['test_expansion_subparsers_2']),
+            (['b', '--help'], expected_value['test_expansion_subparsers_3']),
+        )
+        for args, expected in tests:
+            self.impl_for_subparser_stdout_with_exit(args, expected)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_stderr_with_exit(self):
+        tests = (
+            (['c'], expected_value['test_expansion_subparsers_4']),
+            (['a', '-fff'], expected_value['test_expansion_subparsers_5']),
+            (['a', '16', '--fff', '21', '--baz', 'Y'], expected_value['test_expansion_subparsers_6']),
+            (['b', '16', '--fff', 'X'], expected_value['test_expansion_subparsers_7']),
+        )
+        for args, expected in tests:
+            self.impl_for_subparser_stderr_with_exit(args, expected)
+
+    #--------------------------------------------------------------------------
+    def test_expansion_subparsers_values(self):
+        tests = (
+            (['a', '16'], expected_value['test_expansion_subparsers_defaults_values_1']),
+            (['a', '16', '--fff=9'], expected_value['test_expansion_subparsers_defaults_values_2']),
+            (['a', '16', '--fff', '9'], expected_value['test_expansion_subparsers_defaults_values_2']),
+            (['b', '--fff', 'X'], expected_value['test_expansion_subparsers_defaults_values_3']),
+        )
+        parser = self.setup_subparser()
+        for args, expected in tests:
+            result = parser.parse_args(args=args)
+            self.assertEqual(dict(result), dict(expected), '%s failed' % args)

--- a/configman/tests/test_val_for_argparse.py
+++ b/configman/tests/test_val_for_argparse.py
@@ -1,0 +1,344 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from unittest import TestCase
+
+try:
+    import argparse
+    command_line = argparse
+except ImportError:
+    try:
+        from unittest import SkipTest
+    except ImportError:
+        from nose.plugins.skip import SkipTest
+    raise SkipTest
+
+from mock import Mock
+
+from functools import partial
+
+from configman import Namespace, ConfigurationManager
+from configman.converters import (
+    class_converter,
+    boolean_converter,
+    list_converter,
+    list_to_str,
+)
+
+from configman.def_sources.for_argparse import ArgumentParser
+from configman.value_sources.for_argparse import (
+    #issubclass_with_no_type_error,
+    ValueSource,
+)
+
+
+#------------------------------------------------------------------------------
+def quote_stripping_list_of_ints(a_string):
+    quoteless = a_string.strip('\'"')
+    return list_converter(
+        quoteless,
+        item_separator=' ',
+        item_converter=int
+    )
+
+
+#==============================================================================
+class TestCaseForValSourceArgparse(TestCase):
+
+    #--------------------------------------------------------------------------
+    def setup_value_source(self, type_of_value_source=ValueSource):
+        conf_manager = Mock()
+        conf_manager.argv_source = []
+
+        arg = ArgumentParser()
+        arg.add_argument(
+            '--wilma',
+            dest='wilma',
+        )
+        arg.add_argument(
+            dest='dwight',
+            nargs='*',
+            type=int
+        )
+        vs = type_of_value_source(arg, conf_manager)
+        return vs
+
+    #--------------------------------------------------------------------------
+    def setup_configman_namespace(self):
+        n = Namespace()
+        n.add_option(
+            'alpha',
+            default=3,
+            doc='the first parameter',
+            is_argument=True
+        )
+        n.add_option(
+            'beta',
+            default='the second',
+            doc='the first parameter',
+            short_form='b',
+        )
+        n.add_option(
+            'gamma',
+            default="1 2 3",
+            from_string_converter=quote_stripping_list_of_ints,
+            to_string_converter=partial(
+                list_to_str,
+                delimiter=' '
+            ),
+            secret=True,
+        )
+        n.add_option(
+            'delta',
+            default=False,
+            from_string_converter=boolean_converter
+        )
+        return n
+
+    #--------------------------------------------------------------------------
+    def test_basic_01_defaults(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 3,
+            "beta": "the second",
+            "gamma": [1, 2, 3],
+            "delta": False,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": False
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_02_change_all(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[
+                "16",
+                "-b=THE SECOND",
+                '--gamma="88 99 111 333"',
+                "--delta",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 16,
+            "beta": 'THE SECOND',
+            "gamma": [88, 99, 111, 333],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": False
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_03_with_some_admin(self):
+        option_definitions = self.setup_configman_namespace()
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                '--gamma="-1 -2 -3 -4 -5 -6"',
+                "--delta",
+                "--admin.strict",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [-1, -2, -3, -4, -5, -6],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_04_argparse_doesnt_dominate(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [38, 28, 18, 8],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_05_argparse_overrides_when_appropriate(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        cm = ConfigurationManager(
+            definition_source=option_definitions,
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+                '--gamma="8 18 28 38"',
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_06_argparse_class_expansion(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        other_definition_source = Namespace()
+        other_definition_source.add_option(
+            "a_class",
+            default="configman.tests.test_val_for_modules.Alpha",
+            from_string_converter=class_converter
+        )
+        cm = ConfigurationManager(
+            definition_source=[option_definitions, other_definition_source],
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                "--admin.strict",
+                '--gamma="8 18 28 38"',
+                '--a_class=configman.tests.test_val_for_modules.Beta'
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": True,
+            "admin.expose_secrets": True,
+            "a_class": class_converter(
+                "configman.tests.test_val_for_modules.Beta"
+            ),
+            "b": 23
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])
+
+    #--------------------------------------------------------------------------
+    def test_basic_07_argparse_multilevel_class_expansion(self):
+        option_definitions = self.setup_configman_namespace()
+        other_value_source = {
+            "gamma": [38, 28, 18, 8]
+        }
+        other_definition_source = Namespace()
+        other_definition_source.add_option(
+            "a_class",
+            default="configman.tests.test_val_for_modules.Alpha",
+            from_string_converter=class_converter
+        )
+        cm = ConfigurationManager(
+            definition_source=[option_definitions, other_definition_source],
+            values_source_list=[other_value_source, command_line],
+            argv_source=[
+                "0",
+                "--admin.expose_secrets",
+                "--delta",
+                '--gamma="8 18 28 38"',
+                '--a_class=configman.tests.test_val_for_modules.Delta',
+                '--messy=34'
+            ],
+            use_auto_help=False,
+        )
+        config = cm.get_config()
+
+        expected = {
+            "alpha": 0,
+            "beta": 'the second',
+            "gamma": [8, 18, 28, 38],
+            "delta": True,
+            "admin.print_conf": None,
+            "admin.dump_conf": '',
+            "admin.strict": False,
+            "admin.expose_secrets": True,
+            "a_class": class_converter(
+                "configman.tests.test_val_for_modules.Delta"
+            ),
+            "messy": 34,
+            "dd": class_converter(
+                "configman.tests.test_val_for_modules.Beta"
+            ),
+            'b': 23,
+        }
+
+        for k in config.keys_breadth_first():
+            self.assertEqual(config[k], expected[k])

--- a/configman/value_sources/__init__.py
+++ b/configman/value_sources/__init__.py
@@ -20,7 +20,7 @@ from configman.config_file_future_proxy import ConfigFileFutureProxy
 from configman.config_exceptions import CannotConvertError
 
 # replace with dynamic discovery and loading
-#from configman.value_sources import for_argparse
+from configman.value_sources import for_argparse
 #from configman.value_sources import or_xml
 from configman.value_sources import for_getopt
 from configman.value_sources import for_json
@@ -31,6 +31,7 @@ from configman.value_sources import for_modules
 
 # please replace with dynamic discovery
 for_handlers = [
+    for_argparse,
     for_mapping,
     for_getopt,
     for_json,

--- a/configman/value_sources/for_argparse.py
+++ b/configman/value_sources/for_argparse.py
@@ -1,0 +1,579 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""This module implements a configuration value source from the commandline
+implemented using argparse.  This was a difficult module to make because of
+some fundemental differences with the way that configman and argparse set up
+their respective priorities.
+
+One of the primary problems is that both configman and argparse have their own
+data definition specs.  Configman has Options while argparse has Actions.  Both
+libraries can use their own specs, so a translation layer had to be created.
+
+During the process of configman's overlay/expansion phase, the definitions as
+to what is allowed on the command line change. What was not allowed during an
+earlier pass may be allowed in a later pass.  This means that argparse may need
+to be setup and used several times as the definitions change.
+
+Creating a perfect round trip translation system proved to be impossible
+because the feature sets of argparse and configman do not correspond pefectly.
+So rather than trying to translate everything, each phase of the original
+argparse definitions (args & kwargs) are captured and stored.  Then when
+configman needs to get command line parameters during the overlay/expansion
+process, it is able to perfectly recreate the original arparse parsers tweaked
+with whatever new arguments that the expansion process introduced.
+
+This module introduces a flock of different derivations of argparse parsers.
+Each is used in a different context during the overlay expansion process.
+While several of them are functionally equivalent, we keep them as separate
+classes so that we can use class identity as a differention mechanism.
+"""
+
+import argparse
+import copy
+
+import collections
+
+from configman.option import Option
+from configman.dotdict import DotDict
+from configman.converters import (
+    boolean_converter,
+    to_str,
+)
+from configman.namespace import Namespace
+
+is_command_line_parser = True
+
+can_handle = (
+    argparse,
+)
+
+parser_count = 0
+
+
+#==============================================================================
+class IntermediateConfigmanParser(argparse.ArgumentParser):
+    """"""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        self.subparser_name = kwargs.pop('subparser_name', None)
+        self.configman_subparsers_option = kwargs.pop(
+            'configman_subparsers_option',
+            None
+        )
+        super(IntermediateConfigmanParser, self).__init__(
+            *args, **kwargs
+        )
+        self.required_config = Namespace()
+
+        self._use_argparse_add_help = kwargs.get('add_help', False)
+
+    #--------------------------------------------------------------------------
+    def get_parser_id(self):
+        global parser_count
+        if hasattr(self, 'id'):
+            return
+        self.id = "%03d" % parser_count
+        parser_count += 1
+
+    #--------------------------------------------------------------------------
+    def error(self, message):
+        """we need to suppress errors that might happen in earlier phases of
+        the expansion/overlay process. """
+        if (
+            "not allowed" in message
+            or "ignored" in message
+            or "expected" in message
+            or "invalid" in message
+            or self.add_help
+        ):
+            # when we have "help" then we must also have proper error
+            # processing.  Without "help", we suppress the errors by
+            # doing nothing here
+            super(IntermediateConfigmanParser, self).error(message)
+
+    #--------------------------------------------------------------------------
+    def parse_args(self, args=None, namespace=None, object_hook=None):
+        proposed_config = \
+            super(IntermediateConfigmanParser, self).parse_args(
+                args,
+                namespace
+            )
+        return proposed_config
+
+    #--------------------------------------------------------------------------
+    def parse_known_args(self, args=None, namespace=None, object_hook=None):
+        result = super(IntermediateConfigmanParser, self) \
+            .parse_known_args(args, namespace)
+        try:
+            an_argparse_namespace, extra_arguments = result
+        except TypeError:
+            an_argparse_namespace = argparse.Namespace()
+            extra_arguments = result
+        return (an_argparse_namespace, extra_arguments)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def argparse_namespace_to_dotdict(proposed_config, object_hook=None):
+        if object_hook is None:
+            object_hook = DotDict
+        config = object_hook()
+        for key, value in proposed_config.__dict__.iteritems():
+            config[key] = value
+        return config
+
+counter = 0
+
+
+#==============================================================================
+class FinalStageConfigmanParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        super(FinalStageConfigmanParser, self).__init__(
+            *args, **kwargs
+        )
+
+
+#==============================================================================
+class HelplessConfigmanParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        self.get_parser_id()
+        super(HelplessConfigmanParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class IntermediateConfigmanSubParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        super(IntermediateConfigmanSubParser, self).__init__(
+            *args, **kwargs
+        )
+
+
+#==============================================================================
+class HelplessIntermediateConfigmanSubParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        self.get_parser_id()
+        super(HelplessIntermediateConfigmanSubParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class ConfigmanAdminParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = True
+        #new_kwargs['add_help'] = False
+        new_kwargs['prog'] = 'admin%s' % self.id
+        new_kwargs['parents'] = []
+        super(ConfigmanAdminParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class HelplessConfigmanAdminParser(IntermediateConfigmanParser):
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+        self.get_parser_id()
+        new_kwargs = copy.copy(kwargs)
+        new_kwargs['add_help'] = False
+        new_kwargs['prog'] = 'admin%s' % self.id
+        new_kwargs['parents'] = []
+        super(HelplessConfigmanAdminParser, self).__init__(
+            *args, **new_kwargs
+        )
+
+
+#==============================================================================
+class ParserContainer(object):
+    """this class is a argparse ArgumentParser generator.  Configman uses
+    it to create sets of linked ArgumentParsers of the appropriate types.  It
+    does the translations between configman and argparse.  First it tries to
+    create argparse parameters by fetch original args & kwargs from the
+    foreign_data sections of the configman Options.  Failing that, it tries
+    to translate configman Options as best as it can."""
+    #--------------------------------------------------------------------------
+    def __init__(self, *args, **kwargs):
+
+        self.main_parser_args = DotDict()
+        self.main_parser_args.args = args
+        self.main_parser_args.kwargs = kwargs.copy()
+        self.main_parser_args.kwargs.setdefault('parents', [])
+        self.arguments_for_building_argparse = []
+        self.subcommand = None
+        self.subparser_args_list = []
+        self.subparsers = {}
+        self.admin_parser_args = DotDict()
+        self.admin_parser_args.args = args
+        self.admin_parser_args.kwargs = kwargs.copy()
+        self.admin_arguments = []
+        self._use_argparse_add_help = kwargs.get('add_help', False)
+        self.get_parser_id()
+        self.extra_defaults = {}
+
+    #--------------------------------------------------------------------------
+    def get_parser_id(self):
+        global parser_count
+        if hasattr(self, 'id'):
+            return
+        self.id = "%03d" % parser_count
+        parser_count += 1
+
+    #--------------------------------------------------------------------------
+    def create_argparse_parser(
+        self,
+        main_parser_class=HelplessConfigmanParser,
+        subparser_class=IntermediateConfigmanSubParser,
+        admin_parser_class=ConfigmanAdminParser,
+    ):
+        # create admin parser to be used a a parent parser
+        self.admin_parser_args.kwargs['parents'] = []
+        admin_parser = admin_parser_class(
+            *self.admin_parser_args.args,
+            **self.admin_parser_args.kwargs
+        )
+
+        for admin_args in self.admin_arguments:
+            admin_args.kwargs['default'] = argparse.SUPPRESS
+            admin_parser.add_argument(*admin_args.args, **admin_args.kwargs)
+
+        # create the main parser
+        self.main_parser_args.kwargs['parents'] = [admin_parser]
+        main_parser = main_parser_class(
+            *self.main_parser_args.args,
+            **self.main_parser_args.kwargs
+        )
+
+        if self.subcommand is not None:
+            # add any subparsers to the parent parser
+            subcommand_kwargs = copy.copy(self.subcommand.kwargs)
+            subcommand_kwargs['parser_class'] = subparser_class
+            subcommand_kwargs.setdefault('parents', [])
+            if 'parents' in subcommand_kwargs:
+                del subcommand_kwargs['parents']
+            if 'action' in subcommand_kwargs:
+                del subcommand_kwargs['action']
+            local_subparser_action = main_parser.add_subparsers(
+                *self.subcommand.args,
+                **subcommand_kwargs
+            )
+            local_subparser_action.default = argparse.SUPPRESS
+            for subparser_name in self.subcommand.subparsers.keys():
+                subparser_kwargs = copy.copy(
+                    self.subcommand.subparsers[subparser_name].kwargs
+                )
+                subparser_args = \
+                    self.subcommand.subparsers[subparser_name].args
+                if 'dest' in subparser_kwargs:
+                    del subparser_kwargs['dest']
+                subparser_kwargs['parents'] = [admin_parser]
+                local_subparser = local_subparser_action.add_parser(
+                    *subparser_args,
+                    **subparser_kwargs
+                )
+                self.subparsers[subparser_name] = local_subparser
+
+        # add the actual arguments to the appropriate main or subparsers
+        for args_for_an_argparse_argument in (
+            self.arguments_for_building_argparse
+        ):
+            args = args_for_an_argparse_argument.args
+            kwargs = args_for_an_argparse_argument.kwargs
+            owning_subparser_name = args_for_an_argparse_argument.get(
+                'owning_subparser_name',
+                None
+            )
+            if owning_subparser_name:
+                the_parser = self.subparsers[owning_subparser_name]
+                the_parser.add_argument(*args, **kwargs)
+            else:
+                main_parser.add_argument(*args, **kwargs)
+
+        return main_parser
+
+    #--------------------------------------------------------------------------
+    def _add_argument_from_original_source(self, qualified_name, option):
+        argparse_foreign_data = option.foreign_data.argparse
+        if argparse_foreign_data.flags.subcommand:
+            # this argument represents a subcommand, we must setup the
+            # subparsers
+            self.subcommand = argparse_foreign_data
+            self.subparser_orignal_args = argparse_foreign_data.subparsers
+            self.subcommand_configman_option = option
+
+        else:
+            new_arguments = DotDict()
+            new_arguments.args = argparse_foreign_data.args
+            new_arguments.kwargs = copy.copy(argparse_foreign_data.kwargs)
+            new_arguments.qualified_name = qualified_name
+            new_arguments.owning_subparser_name = \
+                argparse_foreign_data.owning_subparser_name
+
+            if new_arguments.args == (qualified_name.split('.')[-1],):
+                new_arguments.args = (qualified_name,)
+            elif 'dest' in new_arguments.kwargs:
+                if new_arguments.kwargs['dest'] != qualified_name:
+                    new_arguments.kwargs['dest'] = qualified_name
+            else:
+                new_arguments.kwargs['dest'] = qualified_name
+            try:
+                new_arguments.kwargs['dest'] = \
+                    new_arguments.kwargs['dest'].replace('$', '')
+            except KeyError:
+                # there was no 'dest' key, so we can ignore this error
+                pass
+            self.arguments_for_building_argparse.append(new_arguments)
+
+    #--------------------------------------------------------------------------
+    def _add_argument_from_configman_option(self, qualified_name, option):
+        opt_name = qualified_name
+        kwargs = DotDict()
+
+        if option.is_argument:  # is positional argument
+            option_name = opt_name
+        else:
+            option_name = '--%s' % opt_name
+            kwargs.dest = opt_name
+
+        if option.short_form:
+            option_short_form = '-%s' % option.short_form
+            args = (option_name, option_short_form)
+        else:
+            args = (option_name,)
+
+        if option.from_string_converter in (bool, boolean_converter):
+            kwargs.action = 'store_true'
+        else:
+            kwargs.action = 'store'
+
+        kwargs.default = argparse.SUPPRESS
+        kwargs.help = option.doc
+
+        new_arguments = DotDict()
+        new_arguments.args = args
+        new_arguments.kwargs = kwargs
+        new_arguments.qualified_name = qualified_name
+
+        if (
+            isinstance(option.default, collections.Sequence)
+            and not isinstance(option.default, basestring)
+        ):
+            if option.is_argument:
+                kwargs.nargs = len(option.default)
+            else:
+                kwargs.nargs = "+"
+
+        if qualified_name.startswith('admin'):
+            self.admin_arguments.append(new_arguments)
+        else:
+            self.arguments_for_building_argparse.append(new_arguments)
+
+    #--------------------------------------------------------------------------
+    def add_argument_from_option(self, qualified_name, option):
+        if (
+            option.foreign_data is not None
+            and "argparse" in option.foreign_data
+        ):
+            self._add_argument_from_original_source(qualified_name, option)
+        else:
+            self._add_argument_from_configman_option(qualified_name, option)
+
+
+#==============================================================================
+class ValueSource(object):
+    """The ValueSource implementation for the argparse module.  This class will
+    interpret an argv list of commandline arguments using argparse returning
+    a DotDict derivative respresenting the values return by argparse."""
+    #--------------------------------------------------------------------------
+    def __init__(self, source, conf_manager):
+        self.source = source
+        self.parent_parsers = []
+        self.argv_source = tuple(conf_manager.argv_source)
+
+    # frequently, command line data sources must be treated differently.  For
+    # example, even when the overall option for configman is to allow
+    # non-strict option matching, the command line should not arbitrarily
+    # accept bad command line switches.  The existance of this key will make
+    # sure that a bad command line switch will result in an error without
+    # regard to the overall --admin.strict setting.
+    command_line_value_source = True
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _get_known_args(conf_manager):
+        return set(
+            x
+            for x in conf_manager.option_definitions.keys_breadth_first()
+        )
+
+    #--------------------------------------------------------------------------
+    def _option_to_args_list(self, an_option, key):
+        if an_option.is_argument:
+            if an_option.foreign_data is not None:
+                nargs = an_option.foreign_data.argparse.kwargs.get(
+                    'nargs',
+                    None
+                )
+            else:
+                if isinstance(an_option.value, basestring):
+                    return an_option.value
+                if an_option.to_string_converter:
+                    return an_option.to_string_converter(an_option.value)
+                return to_str(an_option.value)
+            if (
+                nargs is not None
+                and isinstance(an_option.value, collections.Sequence)
+            ):
+                if isinstance(an_option.value, basestring):
+                    return an_option.value
+                return [to_str(x) for x in an_option.value]
+            if an_option.value is None:
+                return []
+            return to_str(an_option.value)
+        #if an_option.foreign_data.argparse.kwargs.nargs == 0:
+            #return None
+        if an_option.from_string_converter in (bool, boolean_converter):
+            if an_option.value:
+                return "--%s" % key
+            return None
+        if an_option.value is None:
+            return None
+        return '--%s="%s"' % (
+            key,
+            to_str(an_option)
+        )
+
+    #--------------------------------------------------------------------------
+    def create_fake_args(self, config_manager):
+        # all of this is to keep argparse from barfing if the minumum number
+        # of required arguments is not in place at run time.  It may be that
+        # some config file or environment will bring them in later.   argparse
+        # needs to cope using this placebo argv
+        args = [
+            self._option_to_args_list(
+                config_manager.option_definitions[key],
+                key
+            )
+            for key in config_manager.option_definitions.keys_breadth_first()
+            if (
+                isinstance(
+                    config_manager.option_definitions[key],
+                    Option
+                )
+                and config_manager.option_definitions[key].is_argument
+            )
+        ]
+
+        flattened_arg_list = []
+        for x in args:
+            if isinstance(x, list):
+                flattened_arg_list.extend(x)
+            else:
+                flattened_arg_list.append(x)
+        final_arg_list = [
+            x.strip()
+            for x in flattened_arg_list
+            if x is not None and x.strip() != ''
+        ]
+        try:
+            return final_arg_list + self.extra_args
+        except (AttributeError, TypeError):
+            return final_arg_list
+
+    #--------------------------------------------------------------------------
+    def get_values(self, config_manager, ignore_mismatches, object_hook=None):
+        if ignore_mismatches:
+            self.extra_args = []
+            parser = self._create_new_argparse_instance(
+                {
+                    "main_parser_class": HelplessConfigmanParser,
+                    "subparser_class": HelplessIntermediateConfigmanSubParser,
+                    "admin_parser_class": HelplessConfigmanAdminParser
+                },
+                config_manager,
+                False,  # create auto help
+            )
+            namespace_and_extra_args = parser.parse_known_args(
+                args=self.argv_source
+            )
+
+            try:
+                argparse_namespace, unused_args = namespace_and_extra_args
+                self.extra_args.extend(unused_args)
+            except TypeError:
+                argparse_namespace = argparse.Namespace()
+                self.extra_args.extend(namespace_and_extra_args)
+
+        else:
+            fake_args = self.create_fake_args(config_manager)
+            if (
+                ('--help' in self.argv_source or "-h" in self.argv_source)
+                and '--help' not in fake_args and '-h' not in fake_args
+            ):
+                fake_args.append("--help")
+
+            parser = self._create_new_argparse_instance(
+                {
+                    "main_parser_class": FinalStageConfigmanParser,
+                    "subparser_class": IntermediateConfigmanSubParser,
+                    "admin_parser_class": HelplessConfigmanAdminParser
+                },
+                config_manager,
+                True,  # create Help
+            )
+
+            argparse_namespace = parser.parse_args(
+                args=fake_args,
+            )
+        return parser.argparse_namespace_to_dotdict(
+            argparse_namespace,
+            object_hook,
+        )
+
+    #--------------------------------------------------------------------------
+    def _create_new_argparse_instance(
+        self,
+        parser_classes,
+        config_manager,
+        create_auto_help,
+    ):
+        a_parser = ParserContainer(
+            prog=config_manager.app_name,
+            #version=config_manager.app_version,
+            description=config_manager.app_description,
+            add_help=create_auto_help,
+        )
+        self._setup_argparse(a_parser, parser_classes, config_manager)
+        main_parser = a_parser.create_argparse_parser(**parser_classes)
+        return main_parser
+
+    #--------------------------------------------------------------------------
+    def _setup_argparse(self, parser, parser_classes, config_manager):
+        # need to ensure that admin options are added first, since they'll
+        # go into a subparser and the subparser must be complete before
+        # given to any other parser as a parent
+        for opt_name in config_manager.option_definitions.keys_breadth_first():
+            an_option = config_manager.option_definitions[opt_name]
+            if isinstance(an_option, Option):
+                parser.add_argument_from_option(opt_name, an_option)
+
+    #--------------------------------------------------------------------------
+    @staticmethod
+    def _setup_auto_help(the_config_manager):
+        pass  # there's nothing to do, argparse already has a help feature

--- a/demo/argparse_01.py
+++ b/demo/argparse_01.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+import configman
+
+parser = configman.ArgumentParser()
+parser.parse_args()

--- a/demo/argparse_02.py
+++ b/demo/argparse_02.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("echo")
+args = parser.parse_args()
+print args.echo

--- a/demo/argparse_03.py
+++ b/demo/argparse_03.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", help="display a square of a given number")
+args = parser.parse_args()
+print args.square**2
+

--- a/demo/argparse_04.py
+++ b/demo/argparse_04.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", help="display a square of a given number",
+                    type=int)
+args = parser.parse_args()
+print args.square**2

--- a/demo/argparse_05.py
+++ b/demo/argparse_05.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("--verbosity", help="increase output verbosity")
+args = parser.parse_args()
+if args.verbosity:
+    print "verbosity turned on"

--- a/demo/argparse_06.py
+++ b/demo/argparse_06.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("--verbose", help="increase output verbosity",
+                    action="store_true")
+args = parser.parse_args()
+if args.verbose:
+   print "verbosity turned on"
+

--- a/demo/argparse_07.py
+++ b/demo/argparse_07.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", type=int,
+                    help="display a square of a given number")
+parser.add_argument("-v", "--verbose", action="store_true",
+                    help="increase output verbosity")
+args = parser.parse_args()
+answer = args.square**2
+if args.verbose:
+    print "the square of {} equals {}".format(args.square, answer)
+else:
+    print answer

--- a/demo/argparse_08.py
+++ b/demo/argparse_08.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", type=int,
+                    help="display a square of a given number")
+parser.add_argument("-v", "--verbosity", type=int,
+                    help="increase output verbosity")
+args = parser.parse_args()
+answer = args.square**2
+if args.verbosity == 2:
+    print "the square of {} equals {}".format(args.square, answer)
+elif args.verbosity == 1:
+    print "{}^2 == {}".format(args.square, answer)
+else:
+    print answer

--- a/demo/argparse_09.py
+++ b/demo/argparse_09.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", type=int,
+                    help="display a square of a given number")
+parser.add_argument("-v", "--verbosity", type=int, choices=[0, 1, 2],
+                    help="increase output verbosity")
+args = parser.parse_args()
+answer = args.square**2
+if args.verbosity == 2:
+    print "the square of {} equals {}".format(args.square, answer)
+elif args.verbosity == 1:
+    print "{}^2 == {}".format(args.square, answer)
+else:
+    print answer

--- a/demo/argparse_10.py
+++ b/demo/argparse_10.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", type=int,
+                    help="display the square of a given number")
+parser.add_argument("-v", "--verbosity", action="count",
+                    help="increase output verbosity")
+args = parser.parse_args()
+answer = args.square**2
+if args.verbosity == 2:
+    print "the square of {} equals {}".format(args.square, answer)
+elif args.verbosity == 1:
+    print "{}^2 == {}".format(args.square, answer)
+else:
+    print answer

--- a/demo/argparse_11.py
+++ b/demo/argparse_11.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("square", type=int,
+                    help="display a square of a given number")
+parser.add_argument("-v", "--verbosity", action="count",
+                    help="increase output verbosity")
+args = parser.parse_args()
+answer = args.square**2
+
+# bugfix: replace == with >=
+if args.verbosity >= 2:
+    print "the square of {} equals {}".format(args.square, answer)
+elif args.verbosity >= 1:
+    print "{}^2 == {}".format(args.square, answer)
+else:
+    print answer

--- a/demo/argparse_12.py
+++ b/demo/argparse_12.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("x", type=int, help="the base")
+parser.add_argument("y", type=int, help="the exponent")
+parser.add_argument("-v", "--verbosity", action="count", default=0)
+args = parser.parse_args()
+answer = args.x**args.y
+if args.verbosity >= 2:
+    print "{} to the power {} equals {}".format(args.x, args.y, answer)
+elif args.verbosity >= 1:
+    print "{}^{} == {}".format(args.x, args.y, answer)
+else:
+    print answer

--- a/demo/argparse_13.py
+++ b/demo/argparse_13.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("x", type=int, help="the base")
+parser.add_argument("y", type=int, help="the exponent")
+parser.add_argument("-v", "--verbosity", action="count", default=0)
+args = parser.parse_args()
+answer = args.x**args.y
+if args.verbosity >= 2:
+    print "Running '{}'".format(__file__)
+if args.verbosity >= 1:
+    print "{}^{} ==".format(args.x, args.y),
+print answer

--- a/demo/argparse_14.py
+++ b/demo/argparse_14.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import configman
+parser = configman.ArgumentParser()
+parser.add_argument("x", type=int, help="the base")
+parser.add_argument("y", type=int, help="the exponent")
+parser.add_argument("-v", "--verbosity", action="count", default=0)
+args = parser.parse_args()
+answer = args.x**args.y
+if args.verbosity >= 2:
+    print "Running '{}'".format(__file__)
+if args.verbosity >= 1:
+    print "{}^{} ==".format(args.x, args.y),
+print answer


### PR DESCRIPTION
This is support for configman being a drop in replacement/enhancement for argparse.  It does not make argparse the default commandline processing module, it just makes argparse available.

doc changes, demo and tutorial changes will be in the next PR.
