### PR TITLE
reliable tox testing

### DIFF
--- a/configman/config_manager.py
+++ b/configman/config_manager.py
@@ -905,7 +905,7 @@ class ConfigurationManager(object):
             name='print_conf',
             default=None,
             doc='write current config to stdout (%s)'
-                % ', '.join(file_extension_dispatch.keys())
+                % ', '.join(sorted(file_extension_dispatch.keys()))
         )
         admin.add_option(
             name='dump_conf',

--- a/configman/tests/test_def_for_argparse.py
+++ b/configman/tests/test_def_for_argparse.py
@@ -26,18 +26,18 @@ expected_value = {
                  [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
                  [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
                  [--egg EGG]
-                 {a,b} ...
+                 {b,a} ...
 
 positional arguments:
-  {a,b}                 sub-command help
+  {b,a}                 sub-command help
     a                   a help
     b                   b help
 
 optional arguments:
   -h, --help            show this help message and exit
   --admin.print_conf ADMIN.PRINT_CONF
-                        write current config to stdout (json, py, conf, env,
-                        ini)
+                        write current config to stdout (conf, env, ini, json,
+                        py)
   --admin.dump_conf ADMIN.DUMP_CONF
                         a pathname to which to write the current config
   --admin.strict        mismatched options generate exceptions rather than
@@ -64,8 +64,8 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --admin.print_conf ADMIN.PRINT_CONF
-                        write current config to stdout (json, py, conf, env,
-                        ini)
+                        write current config to stdout (conf, env, ini, json,
+                        py)
   --admin.dump_conf ADMIN.DUMP_CONF
                         a pathname to which to write the current config
   --admin.strict        mismatched options generate exceptions rather than
@@ -86,8 +86,8 @@ optional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --admin.print_conf ADMIN.PRINT_CONF
-                        write current config to stdout (json, py, conf, env,
-                        ini)
+                        write current config to stdout (conf, env, ini, json,
+                        py)
   --admin.dump_conf ADMIN.DUMP_CONF
                         a pathname to which to write the current config
   --admin.strict        mismatched options generate exceptions rather than
@@ -105,8 +105,8 @@ optional arguments:
                  [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
                  [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
                  [--egg EGG]
-                 {a,b} ...
-highwater: error: argument sub_command: invalid choice: 'c' (choose from 'a', 'b')
+                 {b,a} ...
+highwater: error: argument sub_command: invalid choice: 'c' (choose from 'b', 'a')
 """,
     "test_expansion_subparsers_5":
 """usage: highwater a [-h] [--admin.print_conf ADMIN.PRINT_CONF]
@@ -121,7 +121,7 @@ highwater a: error: too few arguments
                  [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
                  [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
                  [--egg EGG]
-                 {a,b} ...
+                 {b,a} ...
 highwater: error: unrecognized arguments: --baz Y
 """,
     "test_expansion_subparsers_7":
@@ -129,7 +129,7 @@ highwater: error: unrecognized arguments: --baz Y
                  [--admin.dump_conf ADMIN.DUMP_CONF] [--admin.strict]
                  [--admin.expose_secrets] [--admin.conf ADMIN.CONF] [--foo]
                  [--egg EGG]
-                 {a,b} ...
+                 {b,a} ...
 highwater: error: unrecognized arguments: 16
 """,
     "test_expansion_subparsers_defaults_values_1":
@@ -467,8 +467,9 @@ class TestCaseForDefSourceArgparse(TestCase):
     def test_expansion_subparsers_stdout_with_exit(self):
         tests = (
             (['--help'], expected_value['test_expansion_subparsers_1']),
-            (['a', '--help'], expected_value['test_expansion_subparsers_2']),
             (['b', '--help'], expected_value['test_expansion_subparsers_3']),
+            (['a', '--help'], expected_value['test_expansion_subparsers_2']),
+
         )
         for args, expected in tests:
             self.impl_for_subparser_stdout_with_exit(args, expected)


### PR DESCRIPTION
@twobraids r?
Now `tox` is always reliable. 